### PR TITLE
Trying to fix workflow actions triggered by pull request

### DIFF
--- a/.github/workflows/meson-test.yml
+++ b/.github/workflows/meson-test.yml
@@ -3,7 +3,7 @@ name: nvme-stas CI
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
   workflow_dispatch:

--- a/meson.build
+++ b/meson.build
@@ -129,11 +129,6 @@ install_subdir(
     install_dir: etcdir,
 )
 
-install_subdir(
-    'usr/lib/modules-load.d',
-    install_dir: join_paths(prefix, 'lib'),
-)
-
 #===============================================================================
 test_env = environment({'MALLOC_PERTURB_': '0'})
 test_env.prepend('PYTHONPATH', meson.current_build_dir())


### PR DESCRIPTION
GitHub implements extra security when submitting a pull request, which prevents being able to read secrets. This is needed to access a private libnvme repo. Long story short, wokflows will always fail when triggered by a pull request. Hopefully, this will fix the issue.