### PR TITLE
Update libnvme APIs

### DIFF
--- a/stafd.py
+++ b/stafd.py
@@ -222,7 +222,7 @@ class Dc(stas.Controller):
 
         if self._alive():
             if self._ctrl.is_registration_supported():
-                self._register_op = stas.AsyncOperationWithRetry(self._on_registration_success, self._on_registration_fail, self._ctrl.registration_ctl, nvme.NVME_TAS_REGISTER)
+                self._register_op = stas.AsyncOperationWithRetry(self._on_registration_success, self._on_registration_fail, self._ctrl.registration_ctlr, nvme.NVMF_DIM_TAS_REGISTER)
                 self._register_op.run_async()
             else:
                 self._get_log_op = stas.AsyncOperationWithRetry(self._on_get_log_success, self._on_get_log_fail, self._ctrl.discover)


### PR DESCRIPTION
TP8010 was merged into upstream libnvme. Some APIs have changed.
This is to update nvme-stas to the new APIs.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>