### PR TITLE
Mount /etc/nvme into docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ x-stas: &default-stas
         GITHUB_REPO: libnvme
         GITHUB_TOKEN:
     volumes:
-        - /run/dbus:/run/dbus      
+        - /run/dbus:/run/dbus
+        - /etc/nvme:/etc/nvme
     privileged: true
     network_mode: host
 


### PR DESCRIPTION
According to https://github.com/linux-nvme/nvme-stas/blob/main/DISTROS.md#things-to-do-post-installation
nvme-stas rely on libnvme
libnvme as well as nvme-cli rely on /etc/nvme/hostnqn and /etc/nvme/hostid
So we map the folder to the container