### PR TITLE
Print descriptive message when unable to run stafctl/stacctl

### DIFF
--- a/stacctl.py
+++ b/stacctl.py
@@ -70,7 +70,8 @@ if ARGS.version:
 
 try:
     ARGS.func(ARGS)
-except dasbus.error.DBusError as ex:
-    sys.exit(f'{ex}')
-except AttributeError as ex:
-    sys.exit(f'{ex}')
+except dasbus.error.DBusError:
+    sys.exit(f'Unable to communicate with {defs.STACD_PROCNAME} over D-Bus. Is {defs.STACD_PROCNAME} running?')
+except AttributeError:
+    PARSER.print_help()
+    sys.exit()

--- a/stafctl.py
+++ b/stafctl.py
@@ -96,7 +96,8 @@ if ARGS.version:
 
 try:
     ARGS.func(ARGS)
-except dasbus.error.DBusError as ex:
-    sys.exit(f'{ex}')
-except AttributeError as ex:
-    sys.exit(f'{ex}')
+except dasbus.error.DBusError:
+    sys.exit(f'Unable to communicate with {defs.STAFD_PROCNAME} over D-Bus. Is {defs.STAFD_PROCNAME} running?')
+except AttributeError:
+    PARSER.print_help()
+    sys.exit()


### PR DESCRIPTION
stafctl/stacctl would print cryptic exception messages on error. 
Now, a clearer message explaining what the problem is will be displayed.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>