### PR TITLE
Filter out invalid IP addresses.

### DIFF
--- a/.github/workflows/meson-test.yml
+++ b/.github/workflows/meson-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install requirements
         run: |
-          sudo apt-get install -y python3-pyudev python3-systemd python3-gi meson
+          sudo apt-get install -y python3-pyudev python3-systemd python3-gi python3-netifaces meson
           python -m pip install --upgrade pip dasbus pylint pyflakes
 
       - name: Checkout libnvme

--- a/DISTROS.md
+++ b/DISTROS.md
@@ -31,6 +31,7 @@ nvme-stas also depends on the following run-time libraries and modules. Note tha
 | ----------------------------------------------- | ----------- | ------------- | ------------- |
 | libnvme                                         | 1.0         | **Mandatory** | **Mandatory** |
 | python3-dasbus                                  | 1.6         | **Mandatory** | **Mandatory** |
+| python3-netifaces                               | 0.10.4      | **Mandatory** | **Mandatory** |
 | python3-pyudev                                  | 0.22.0      | **Mandatory** | **Mandatory** |
 | python3-systemd                                 | 234         | **Mandatory** | **Mandatory** |
 | python3-gi (Debian) OR python3-gobject (Fedora) | 3.36.0      | **Mandatory** | **Mandatory** |

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM $registry/$base:$version
 
 WORKDIR /root
 
-RUN dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject meson
+RUN dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject python3-netifaces meson
 # TODO: once libnvme project has a package, use: dnf install -y libnvme
 COPY --from=libnvme-builder /root/install /
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ The following packages must be installed to use **`stafd`**/**`stacd`**
 **Debian packages (tested on Ubuntu 20.04):**
 
 ```bash
-sudo apt-get install -y python3-pyudev python3-systemd python3-gi
+sudo apt-get install -y python3-pyudev python3-systemd python3-gi python3-netifaces
 sudo pip3 install dasbus
 ```
 
 **Yum packages (tested on Fedora 34):**
 
 ```bash
-sudo dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject
+sudo dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject python3-netifaces
 ```
 
 Additionally, the `libnvme` library (with Python bindings) needs to be installed. Currently only available from source at: https://github.com/linux-nvme/libnvme

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Standards-Version: 4.4.1
 
 Package: nvme-stas
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-pyudev, python3-systemd, python3-gi
+Depends: ${python3:Depends}, ${misc:Depends}, python3-pyudev, python3-systemd, python3-gi, python3-netifaces
 Description: NVMe STorage Appliance Services
  This package provides two daemons, stafd and stacd. The STorage Appliance
  Finder Daemon (stafd) automatically discovers NVMe-oF Discovery Controllers (DC)

--- a/meson.build
+++ b/meson.build
@@ -39,11 +39,12 @@ endif
 check_pymodules = get_option('check_pymodules')
 if check_pymodules
     py_modules_reqd = [
-        ['libnvme', 'This library must be installed from sources (at this time)'],
-        ['dasbus',  'Install python3-dasbus (rpm) OR pip3 install dasbus'],
-        ['pyudev',  'Install python3-pyudev (deb/rpm)'],
-        ['systemd', 'Install python3-systemd (deb/rpm)'],
-        ['gi',      'Install python3-gi (deb) OR python3-gobject (rpm)'],
+        ['libnvme',   'This library must be installed from sources (at this time)'],
+        ['dasbus',    'Install python3-dasbus (rpm) OR pip3 install dasbus'],
+        ['pyudev',    'Install python3-pyudev (deb/rpm)'],
+        ['netifaces', 'Install python3-netifaces (deb/rpm)'],
+        ['systemd',   'Install python3-systemd (deb/rpm)'],
+        ['gi',        'Install python3-gi (deb) OR python3-gobject (rpm)'],
     ]
     if want_man or want_html
         py_modules_reqd += [['lxml', 'Install python3-lxml (deb/rpm)']]

--- a/stacd.py
+++ b/stacd.py
@@ -223,6 +223,7 @@ class Stac(stas.Service):
         LOG.debug('Stac._config_ctrls_finish()        - discovered_ctrl_list = %s', discovered_ctrl_list)
 
         controllers = stas.remove_blacklisted(configured_ctrl_list + discovered_ctrl_list)
+        controllers = stas.remove_invalid_addresses(controllers)
 
         new_controller_ids = { stas.TransportId(controller) for controller in controllers }
         cur_controller_ids = set(self._controllers.keys())

--- a/stafd.py
+++ b/stafd.py
@@ -435,6 +435,7 @@ class Staf(stas.Service):
         LOG.debug('Staf._config_ctrls_finish()        - referral_ctrl_list    = %s', referral_ctrl_list)
 
         controllers = stas.remove_blacklisted(configured_ctrl_list + discovered_ctrl_list + referral_ctrl_list)
+        controllers = stas.remove_invalid_addresses(controllers)
 
         new_controller_ids = { stas.TransportId(controller) for controller in controllers }
         cur_controller_ids = set(self._controllers.keys())

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -16,6 +16,8 @@ import atexit
 import logging as LG
 import configparser
 import platform
+import ipaddress
+import netifaces
 import pyudev
 import systemd.daemon
 import dasbus.connection
@@ -701,6 +703,39 @@ def remove_blacklisted(controllers:list):
         LOG.debug('remove_blacklisted()               - blacklisted_ctrl_list = %s', blacklisted_ctrl_list)
         controllers = [ controller for controller in controllers if not blacklisted(blacklisted_ctrl_list, controller) ]
     return controllers
+
+#*******************************************************************************
+def remove_invalid_addresses(controllers:list):
+    valid_controllers = list()
+    for controller in controllers:
+        # First, let's make sure that traddr is
+        # syntactically a valid IPv4 or IPv6 address.
+        traddr = controller.get('traddr')
+        try:
+            ip = ipaddress.ip_address(traddr)
+        except ValueError:
+            LOG.warning('controller traddr=%s is not valid', traddr)
+            continue
+
+        # Next, if the interface is not specified, we'll assume that the
+        # IP address is valid and that there is a route to reach traddr.
+        iface = controller.get('host-iface')
+        if not iface:
+            valid_controllers.append(controller)
+        else:
+            # Finally, if there is an interface specified, let's make sure
+            # that the interface is enabled to connect using traddr. In other
+            # words, if traddr is an IPv4 address, then the interface must have
+            # IPv4 enabled. Same logic applies to IPv6.
+            ifaddresses = netifaces.ifaddresses(iface) # List of IP addresses configured on the interface
+            if ( (ip.version == 4 and netifaces.AF_INET in ifaddresses) or
+                 (ip.version == 6 and netifaces.AF_INET6 in ifaddresses) ):
+                valid_controllers.append(controller)
+            else:
+                LOG.warning('controller traddr=%s rejected because interface %s is not configured for IPv%s',
+                            traddr, iface, ip.version)
+
+    return valid_controllers
 
 #*******************************************************************************
 class TransportId:


### PR DESCRIPTION
When the Avahi daemon detects Discovery Controllers over mDNS, it will report all IP address families (IPv4 and IPv6) being advertized. However, the host may not be configured to support all IP address families being advertized and should only try to connect with the IP address family that is supported for a given interface. This patch solves this issue.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>