### PR TITLE
Add ignore-iface and ip-family config options

### DIFF
--- a/etc/stas/stacd.conf
+++ b/etc/stas/stacd.conf
@@ -39,6 +39,65 @@
 #              Unit:  Seconds
 #kato=120
 
+# ignore-iface: This option controls how connections with I/O Controllers (IOC)
+#               are made.
+#
+#               There is no guarantee that there will be a route to reach that
+#               IOC. However, we can use the socket option SO_BINDTODEVICE to
+#               force the connection to be made on a specific interface instead
+#               of letting the routing tables decide where to make the connection.
+#
+#               This option determines whether stacd will use SO_BINDTODEVICE to
+#               force connections on an interface or just rely on the routing
+#               tables. The default is to use SO_BINDTODEVICE, in other words,
+#               stacd does not ignore the interface.
+#
+#               BACKGROUND:
+#               By default, stacd will connect to IOCs on the same interface that
+#               was used to retrieve the discovery log pages. If stafd discovers
+#               a DC on an interface using mDNS, and stafd connects to that DC
+#               and retrieves the log pages, it is expected that the storage
+#               subsystems listed in the log pages are reachable on the same
+#               interface where the DC was discovered.
+#
+#               For example, let's say a DC is discovered on interface ens102.
+#               Then all the subsystems listed in the log pages retrieved from
+#               that DC must be reachable on interface ens102. If this doesn't
+#               work, for example you cannot "ping -I ens102 [storage-ip]", then
+#               the most likely explanation is that arp proxy is not enabled on
+#               the switch that the host is connected to on interface ens102.
+#               Whatever you do, resist the temptation to manually set up the
+#               routing tables or to add alternate routes going over a different
+#               interface than the one where the DC is located. That simply
+#               won't work. Make sure arp proxy is enabled on the switch first.
+#
+#               Setting routes won't work because, by default, stacd uses the
+#               SO_BINDTODEVICE socket option when it connects to IOCs. This
+#               option is used to force a socket connection to be made on a
+#               specific interface instead of letting the routing tables decide
+#               where to connect the socket. Even if you were to manually
+#               configure an alternate route on a different interface, the
+#               connections (i.e. host to IOC) will still be made on the
+#               interface where the DC was discovered by stafd.
+#
+#               Type:    boolean
+#               Range:   [false, true]
+#               Default: true
+#ignore-iface=false
+
+# ip-family: With this you can specify whether stacd will support IPv4, IPv6,
+#            or both when connecting to I/O Controllers (IOC). stacd will
+#            not try to connect to IP addresses (whether they come from the
+#            discovery log pages or manually configured with the 'controller'
+#            option defined below) if those IP addresses are disabled by this
+#            option. stacd will default to "ipv4+ipv6" if an invalid value is
+#            specified for this option.
+#
+#            Type:    String
+#            Range:   [ipv4, ipv6, ipv4+ipv6]
+#            Default: ipv4+ipv6
+#ip-family=ipv4+ipv6
+
 [Controllers]
 # controller: I/O Controllers (IOC) are specified with this keyword.
 #

--- a/etc/stas/stafd.conf
+++ b/etc/stas/stafd.conf
@@ -47,6 +47,42 @@
 #                         Range: [false, true]
 #persistent-connections=true
 
+# ignore-iface: This option controls how connections with Discovery Controllers
+#               (DC) are made.
+#
+#               DCs are automatically discovered using DNS-SD/mDNS. mDNS
+#               provides the DC's IP address and the interface on which the DC
+#               was discovered.
+#
+#               There is no guarantee that there will be a route to reach that
+#               DC. However, we can use the socket option SO_BINDTODEVICE to
+#               force the connection to be made on a specific interface instead
+#               of letting the routing tables decide where to make the
+#               connection.
+#
+#               This option determines whether stafd will use SO_BINDTODEVICE to
+#               force connections on an interface or just rely on the routing
+#               tables. The default is to use SO_BINDTODEVICE, in other words,
+#               stafd does not ignore the interface.
+#
+#               Type:    boolean
+#               Range:   [false, true]
+#               Default: false
+#ignore-iface=false
+
+# ip-family: With this you can specify whether stafd will support IPv4, IPv6,
+#            or both when connecting to Discovery Controllers (DC). stafd will
+#            not try to connect to IP addresses (whether discovered with mDNS
+#            or manually configured with the 'controller' option defined below)
+#            if those IP addresses are disabled by this option. stafd will
+#            default to "ipv4+ipv6" if an invalid value is specified for this
+#            option.
+#
+#            Type:    String
+#            Range:   [ipv4, ipv6, ipv4+ipv6]
+#            Default: ipv4+ipv6
+#ip-family=ipv4+ipv6
+
 [Service Discovery]
 # zeroconf: Control whether DNS-SD/mDNS automatic discovery is enabled. This is
 #           used to enable or disable automatic discovery of Discovery


### PR DESCRIPTION
The configuration files offer two new options.
1) **ignore-iface** tells stafd/stacd not to use SO_BINDTODEVICE
2) **ip-family** tells stafd/stacd which IP address families to support

Signed-off-by: Martin Belanger <martin.belanger@dell.com>