### PR TITLE
Remove misconfiguration check

### DIFF
--- a/.github/workflows/meson-test.yml
+++ b/.github/workflows/meson-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install requirements
         run: |
-          sudo apt-get install -y libjson-c-dev python3-pyudev python3-systemd python3-gi python3-netifaces meson
+          sudo apt-get install -y libjson-c-dev python3-pyudev python3-systemd python3-gi meson
           python -m pip install --upgrade pip dasbus pylint pyflakes
 
       - uses: BSFishy/meson-build@v1.0.3

--- a/DISTROS.md
+++ b/DISTROS.md
@@ -31,7 +31,6 @@ nvme-stas also depends on the following run-time libraries and modules. Note tha
 | ----------------------------------------------- | ----------- | ------------- | ------------- |
 | libnvme                                         | 1.0         | **Mandatory** | **Mandatory** |
 | python3-dasbus                                  | 1.6         | **Mandatory** | **Mandatory** |
-| python3-netifaces                               | 0.10.4      | **Mandatory** | **Mandatory** |
 | python3-pyudev                                  | 0.22.0      | **Mandatory** | **Mandatory** |
 | python3-systemd                                 | 234         | **Mandatory** | **Mandatory** |
 | python3-gi (Debian) OR python3-gobject (Fedora) | 3.36.0      | **Mandatory** | **Mandatory** |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM $registry/$base:$version
 WORKDIR /root
 
 # for nvme-stas
-RUN dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject python3-netifaces meson
+RUN dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject meson
 # for libnvme
 RUN dnf install -y git gcc g++ cmake openssl-devel libuuid-devel json-c-devel swig python-devel meson
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ The following packages must be installed to use **`stafd`**/**`stacd`**
 **Debian packages (tested on Ubuntu 20.04):**
 
 ```bash
-sudo apt-get install -y python3-pyudev python3-systemd python3-gi python3-netifaces
+sudo apt-get install -y python3-pyudev python3-systemd python3-gi
 sudo pip3 install dasbus
 ```
 
 **RPM packages (tested on Fedora 34..35 and SLES15):**
 
 ```bash
-sudo dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject python3-netifaces
+sudo dnf install -y python3-dasbus python3-pyudev python3-systemd python3-gobject
 ```
 
 # STAF - STorage Appliance Finder

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Standards-Version: 4.4.1
 
 Package: nvme-stas
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-pyudev, python3-systemd, python3-gi, python3-netifaces
+Depends: ${python3:Depends}, ${misc:Depends}, python3-pyudev, python3-systemd, python3-gi
 Description: NVMe STorage Appliance Services
  This package provides two daemons, stafd and stacd. The STorage Appliance
  Finder Daemon (stafd) automatically discovers NVMe-oF Discovery Controllers (DC)

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,6 @@ if check_pymodules
     py_modules_reqd = [
         ['dasbus',    'Install python3-dasbus (rpm) OR pip3 install dasbus'],
         ['pyudev',    'Install python3-pyudev (deb/rpm)'],
-        ['netifaces', 'Install python3-netifaces (deb/rpm)'],
         ['systemd',   'Install python3-systemd (deb/rpm)'],
         ['gi',        'Install python3-gi (deb) OR python3-gobject (rpm)'],
     ]

--- a/nvme-stas.spec.in
+++ b/nvme-stas.spec.in
@@ -19,7 +19,6 @@ Requires:      python3-dasbus
 Requires:      python3-pyudev
 Requires:      python3-systemd
 Requires:      python3-gobject
-Requires:      python3-netifaces
 
 %description
 NVMe STorage Appliance Services

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -17,7 +17,6 @@ import logging as LG
 import configparser
 import platform
 import ipaddress
-import netifaces
 import pyudev
 import systemd.daemon
 import dasbus.connection
@@ -754,23 +753,7 @@ def remove_invalid_addresses(controllers:list):
                       TransportId(controller), ip.version, CNF.conf_file)
             continue
 
-        # Next, if the interface is not specified, we'll assume that the
-        # IP address is valid and that there is a route to reach traddr.
-        iface = controller.get('host-iface')
-        if not iface:
-            valid_controllers.append(controller)
-        else:
-            # Finally, if there is an interface specified, let's make sure
-            # that the interface is enabled to connect using traddr. In other
-            # words, if traddr is an IPv4 address, then the interface must have
-            # IPv4 enabled. Same logic applies to IPv6.
-            ifaddresses = netifaces.ifaddresses(iface) # List of IP addresses configured on the interface
-            if ( (ip.version == 4 and netifaces.AF_INET in ifaddresses) or
-                 (ip.version == 6 and netifaces.AF_INET6 in ifaddresses) ):
-                valid_controllers.append(controller)
-            else:
-                LOG.warning('%s rejected because interface %s is not configured for IPv%s',
-                            TransportId(controller), iface, ip.version)
+        valid_controllers.append(controller)
 
     return valid_controllers
 


### PR DESCRIPTION
This is to remove a dependency on python3-netifaces, which seems
to not be maintained anymore. Will have to revisit misconfiguration
checks in a future (yet to be determined) release.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>