### PR TITLE
dbus: return native dbus data instead of json when possible.

### DIFF
--- a/stacctl.py
+++ b/stacctl.py
@@ -32,7 +32,7 @@ def status(args):
     bus = SystemMessageBus()
     iface = bus.get_proxy(defs.STACD_DBUS_NAME, defs.STACD_DBUS_PATH)
     info = json.loads(iface.process_info())
-    info['controllers'] = json.loads(iface.list_controllers(True))
+    info['controllers'] = iface.list_controllers(True)
     for controller in info['controllers']:
         transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn = _extract_cid(controller)
         controller.update(json.loads(iface.controller_info(transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn)))
@@ -42,7 +42,7 @@ def status(args):
 def ls(args):
     bus = SystemMessageBus()
     iface = bus.get_proxy(defs.STACD_DBUS_NAME, defs.STACD_DBUS_PATH)
-    info = json.loads(iface.list_controllers(args.detailed))
+    info = iface.list_controllers(args.detailed)
     print(pprint.pformat(info, width=120))
 
 PARSER = ArgumentParser(description=f'{defs.STAC_DESCRIPTION} ({defs.STAC_ACRONYM})')

--- a/stacd.py
+++ b/stacd.py
@@ -35,7 +35,7 @@ DBUS_IDL = '''
     <interface name="%s">
         <method name="list_controllers">
             <arg direction="in" type="b" name="detailed"/>
-            <arg direction="out" type="s" name="controller_list_json"/>
+            <arg direction="out" type="aa{ss}" name="controller_list"/>
         </method>
     </interface>
 </node>
@@ -160,7 +160,7 @@ class Stac(stas.Service):
             return json.dumps(controller.info()) if controller else '{}'
 
         def list_controllers(self, detailed) -> str: # pylint: disable=no-self-use
-            return json.dumps([ controller.details() if detailed else controller.controller_id_dict() for controller in STAC.get_controllers() ])
+            return [ controller.details() if detailed else controller.controller_id_dict() for controller in STAC.get_controllers() ]
 
 
     #===========================================================================

--- a/stafctl.py
+++ b/stafctl.py
@@ -32,10 +32,10 @@ def status(args):
     bus = SystemMessageBus()
     iface = bus.get_proxy(defs.STAFD_DBUS_NAME, defs.STAFD_DBUS_PATH)
     info = json.loads(iface.process_info())
-    info['controllers'] = json.loads(iface.list_controllers(True))
+    info['controllers'] = iface.list_controllers(True)
     for controller in info['controllers']:
         transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn = _extract_cid(controller)
-        controller['log_pages'] = json.loads(iface.get_log_pages(transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn))
+        controller['log_pages'] = iface.get_log_pages(transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn)
         controller.update(json.loads(iface.controller_info(transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn)))
 
     print(pprint.pformat(info, width=120))
@@ -43,13 +43,13 @@ def status(args):
 def ls(args):
     bus = SystemMessageBus()
     iface = bus.get_proxy(defs.STAFD_DBUS_NAME, defs.STAFD_DBUS_PATH)
-    info  = json.loads(iface.list_controllers(args.detailed))
+    info  = iface.list_controllers(args.detailed)
     print(pprint.pformat(info, width=120))
 
 def dlp(args):
     bus = SystemMessageBus()
     iface = bus.get_proxy(defs.STAFD_DBUS_NAME, defs.STAFD_DBUS_PATH)
-    info = json.loads(iface.get_log_pages(args.transport, args.traddr, args.trsvcid, args.host_traddr, args.host_iface, args.nqn))
+    info = iface.get_log_pages(args.transport, args.traddr, args.trsvcid, args.host_traddr, args.host_iface, args.nqn)
     print(pprint.pformat(info, width=120))
 
 def adlp(args):

--- a/stafd.py
+++ b/stafd.py
@@ -35,7 +35,7 @@ DBUS_IDL = '''
     <interface name="%s">
         <method name="list_controllers">
             <arg direction="in" type="b" name="detailed"/>
-            <arg direction="out" type="s" name="controller_list_json"/>
+            <arg direction="out" type="aa{ss}" name="controller_list"/>
         </method>
         <method name="get_log_pages">
             <arg direction="in" type="s" name="transport"/>
@@ -44,7 +44,7 @@ DBUS_IDL = '''
             <arg direction="in" type="s" name="host_traddr"/>
             <arg direction="in" type="s" name="host_iface"/>
             <arg direction="in" type="s" name="subsysnqn"/>
-            <arg direction="out" type="s" name="log_pages_json"/>
+            <arg direction="out" type="aa{ss}" name="log_pages"/>
         </method>
         <method name="get_all_log_pages">
             <arg direction="in" type="b" name="detailed"/>
@@ -351,7 +351,7 @@ class Staf(stas.Service):
 
         def get_log_pages(self, transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn) -> str: # pylint: disable=no-self-use,too-many-arguments
             controller = STAF.get_controller(transport, traddr, trsvcid, host_traddr, host_iface, subsysnqn)
-            return json.dumps(controller.log_pages()) if controller else '[]'
+            return controller.log_pages() if controller else '[]'
 
         def get_all_log_pages(self, detailed) -> str: # pylint: disable=no-self-use
             log_pages = list()
@@ -363,7 +363,7 @@ class Staf(stas.Service):
         def list_controllers(self, detailed) -> str: # pylint: disable=no-self-use
             ''' @brief Return the list of discovery controller IDs
             '''
-            return json.dumps([ controller.details() if detailed else controller.controller_id_dict() for controller in STAF.get_controllers() ])
+            return [ controller.details() if detailed else controller.controller_id_dict() for controller in STAF.get_controllers() ]
 
 
     #===========================================================================

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -1234,7 +1234,7 @@ class Controller:
     def details(self) -> dict:
         details = self.controller_id_dict()
         details.update(UDEV.get_attributes(self.device, ('hostid', 'hostnqn', 'model', 'serial')))
-        details['connect attempts'] = self._connect_attempts
+        details['connect attempts'] = str(self._connect_attempts)
         details['retry connect timer'] = str(self._retry_connect_tmr)
         return details
 


### PR DESCRIPTION
Some of the DBus methods return json-formatted output. For some of
the methods, by making a few changes. it was possible to return
native DBus data (e.g. aa{ss}). Unfortunately, some methods return
data that is too complex to express as simple DBus data and the use
of Variants woulld be too complicated. Those methods will continue
to return data in json format, which allows more flexibility.

This addresses issue: https://github.com/linux-nvme/nvme-stas/issues/40

Signed-off-by: Martin Belanger <martin.belanger@dell.com>