### PR TITLE
Do not call libnvme's persistent_set()

### DIFF
--- a/etc/stas/stafd.conf
+++ b/etc/stas/stafd.conf
@@ -33,11 +33,11 @@
 
 # kato:        Keep Alive Timeout (KATO): This field specifies the timeout value
 #              for the Keep Alive feature in seconds. The default value for this
-#              field is 120 seconds (2 minutes).
+#              field is 30 seconds.
 #              Type:  Unsigned integer
 #              Range: 0..N
 #              Unit:  Seconds
-#kato=120
+#kato=30
 
 # persistent-connections: Whether connections to Discovery Controllers (DC)
 #                         are persistent. If stafd is stopped, the connections


### PR DESCRIPTION
The API `persistent_set()` from `libnvme` has absolutely no effect on connections. Most importantly, it does not set a default KATO on persistent Discovery Controller (DC) connections.

I/O Controller (IOC) connections, on the other hand, are assigned a default 2-minute KATO by the kernel regardless of `persistent_set()`.

Instead of calling `persistent_set()` (which, by the way, will be removed from `libnvme`), one should always set a default KATO on persistent DC connections. For IOC connections, however, setting a default KATO is optional because, as mentioned above, the kernel will assign one when not specified by the user.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>