### PR TITLE
Remove deprecated distutils module

### DIFF
--- a/staslib/defs.py
+++ b/staslib/defs.py
@@ -8,6 +8,8 @@
 
 ''' @brief This file gets automagically configured by meson at build time.
 '''
+from staslib.version import KernelVersion
+
 VERSION           = '@VERSION@'
 LICENSE           = '@LICENSE@'
 PROJECT_NAME      = '@PROJECT_NAME@'
@@ -29,5 +31,5 @@ STAFD_DBUS_PATH   = '@STAFD_DBUS_PATH@'
 STAFD_EXECUTABLE  = '@STAFD_EXECUTABLE@'
 STAFD_CONFIG_FILE = '@STAFD_CONFIG_FILE@'
 
-KERNEL_IFACE_MIN_VERSION   = '@KERNEL_IFACE_MIN_VERSION@'
-KERNEL_TP8013_MIN_VERSION = '@KERNEL_TP8013_MIN_VERSION@'
+KERNEL_IFACE_MIN_VERSION  = KernelVersion('@KERNEL_IFACE_MIN_VERSION@')
+KERNEL_TP8013_MIN_VERSION = KernelVersion('@KERNEL_TP8013_MIN_VERSION@')

--- a/staslib/meson.build
+++ b/staslib/meson.build
@@ -14,7 +14,7 @@ defs_py = configure_file(
 )
 
 configured_files   = [ defs_py ]
-unconfigured_files = [ '__init__.py', 'avahi.py', 'glibudev.py', 'stas.py' ]
+unconfigured_files = [ '__init__.py', 'avahi.py', 'glibudev.py', 'stas.py', 'version.py' ]
 
 python3.install_sources(
     unconfigured_files + configured_files,
@@ -33,8 +33,9 @@ endforeach
 #===============================================================================
 if libnvme_found
     modules_to_test = [
-        [ 'staslib.avahi', 'avahi.py' ],
-        [ 'staslib.stas',  'stas.py'  ],
+        [ 'staslib.avahi',   'avahi.py'   ],
+        [ 'staslib.stas',    'stas.py'    ],
+        [ 'staslib.version', 'version.py' ],
     ]
 
     foreach module: modules_to_test

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -17,7 +17,6 @@ import logging as LG
 import configparser
 import platform
 import ipaddress
-from distutils.version import LooseVersion
 import pyudev
 import systemd.daemon
 import dasbus.connection
@@ -28,6 +27,7 @@ except ModuleNotFoundError:
 
 from gi.repository import Gio, GLib, GObject
 from libnvme import nvme
+from staslib.version import KernelVersion
 from staslib import defs
 
 DC_KATO_DEFAULT = 30 # seconds
@@ -418,7 +418,7 @@ def get_sysconf():   # pylint: disable=missing-function-docstring
 
 
 #*******************************************************************************
-KERNEL_VERSION = platform.release()
+KERNEL_VERSION = KernelVersion(platform.release())
 
 class NvmeOptions():
     ''' Object used to read and cache contents of file /dev/nvme-fabrics.
@@ -432,8 +432,8 @@ class NvmeOptions():
         # version meets the minimum version for that option, then we don't
         # even need to read '/dev/nvme-fabrics'.
         self._supported_options = {
-            'discovery':  LooseVersion(KERNEL_VERSION) >= LooseVersion(defs.KERNEL_TP8013_MIN_VERSION),
-            'host_iface': LooseVersion(KERNEL_VERSION) >= LooseVersion(defs.KERNEL_IFACE_MIN_VERSION),
+            'discovery':  KERNEL_VERSION >= defs.KERNEL_TP8013_MIN_VERSION,
+            'host_iface': KERNEL_VERSION >= defs.KERNEL_IFACE_MIN_VERSION,
         }
 
         # If some of the options are False, we need to check wether they can be

--- a/staslib/version.py
+++ b/staslib/version.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2021, Dell Inc. or its subsidiaries.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See the LICENSE file for details.
+#
+# This file is part of NVMe STorage Appliance Services (nvme-stas).
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+#
+''' distutils (and hence LooseVersion) is being deprecated. None of the
+    suggested replacements (e.g. from pkg_resources import parse_version) quite
+    work with Linux kernel versions the way LooseVersion does.
+
+    It was suggested to simply lift the LooseVersion code and vendor it in,
+    which is what this module is about.
+'''
+
+import re
+
+class KernelVersion():
+    ''' Code loosely lifted from distutils's LooseVersion
+    '''
+    component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
+
+    def __init__(self, string:str):
+        self.string = string
+        self.version = self.__parse(string)
+
+    def __str__ (self):
+        return self.string
+
+    def __repr__ (self):
+        return f'KernelVersion ("{self}")'
+
+    def __eq__(self, other):
+        return self.version == self.__version(other)
+
+    def __lt__(self, other):
+        return self.version < self.__version(other)
+
+    def __le__(self, other):
+        return self.version <= self.__version(other)
+
+    def __gt__(self, other):
+        return self.version > self.__version(other)
+
+    def __ge__(self, other):
+        return self.version >= self.__version(other)
+
+    @staticmethod
+    def __version(obj):
+        return obj.version if isinstance(obj, KernelVersion) else KernelVersion.__parse(obj)
+
+    @staticmethod
+    def __parse(string):
+        components = []
+        for item in KernelVersion.component_re.split(string):
+            if item and item != '.':
+                try:
+                    components.append(int(item))
+                except ValueError:
+                    pass
+
+        return components


### PR DESCRIPTION
[PEP632](https://peps.python.org/pep-0632/) announces the deprecation of `distutils`. `nvme-stas` relies on `distutils.version.LooseVersion`, but none of the suggested replacements work as well as `distutils.version.LooseVersion` for handling Linux version strings such as `5.8.0-63-generic`.

This patch introduces the class `KernelVersion` that can be used to parse the Linux kernel version similar to how `LooseVersion` does it.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>