### PR TITLE
build: fix spec file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,9 @@ ifneq ("$(wildcard ${BUILD-DIR})","")
 	rm -rf ${BUILD-DIR}
 endif
 
-.PHONY: install test
-install test: ${BUILD-DIR}
-	cd ${BUILD-DIR} && meson $@
-
-.PHONY: dist
-dist: ${BUILD-DIR}
-	cd ${BUILD-DIR} && meson $@
+.PHONY: install test dist
+install test dist: ${BUILD-DIR}
+	meson $@ -C ${BUILD-DIR}
 
 .PHONY: loc
 loc:

--- a/nvme-stas.spec.in
+++ b/nvme-stas.spec.in
@@ -7,25 +7,25 @@ Version: @VERSION@
 Release: 1%{?dist}
 License: @LICENSE@
 URL:     https://github.com/linux-nvme/nvme-stas
-Source0: %{url}/archive/v%{version_no_tilde}/%{name}-%{version_no_tilde}.tar.gz
+Source0: %{name}-%{version}.tar.xz
 
 BuildArch: noarch
 
 BuildRequires: meson
 BuildRequires: glib2-devel
-BuildRequires: libnvme-devel
+#BuildRequires: libnvme-devel
 BuildRequires: libxslt
 BuildRequires: docbook-style-xsl
 BuildRequires: systemd-devel
 BuildRequires: systemd-rpm-macros
 
 BuildRequires: python3
-BuildRequires: python3-devel
+#BuildRequires: python3-devel
 BuildRequires: python3-pyflakes
 BuildRequires: python3-pylint
 BuildRequires: pylint
 
-BuildRequires: python3-libnvme
+#BuildRequires: python3-libnvme
 BuildRequires: python3-dasbus
 BuildRequires: python3-pyudev
 BuildRequires: python3-systemd
@@ -33,7 +33,7 @@ BuildRequires: python3-gobject-devel
 BuildRequires: python3-lxml
 
 Requires:      avahi
-Requires:      python3-libnvme
+#Requires:      python3-libnvme
 Requires:      python3-dasbus
 Requires:      python3-pyudev
 Requires:      python3-systemd
@@ -47,7 +47,7 @@ and Manual configuration. nvme-stas is composed of two daemons:
 stafd (STorage Appliance Finder) and stacd (STorage Appliance Connector).
 
 %prep
-%autosetup -p1 -n %{name}-%{version_no_tilde}
+%autosetup -p1 -n %{name}-%{version}
 
 %build
 %meson -Dman=true -Dhtml=true


### PR DESCRIPTION
The spec file got broken when I tried to align it with upstream
projects. So, I'm reverting some of the changes with this patch.

Related to: https://github.com/linux-nvme/nvme-stas/issues/76.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>