### PR TITLE
meson: explicitly set 'check: false' when invoking run_command()

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -15,7 +15,7 @@ if want_man or want_html
 
     if xsltproc.found()
         manpage_style = 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
-        if run_command(xsltproc, '--nonet', manpage_style).returncode() != 0
+        if run_command(xsltproc, '--nonet', manpage_style, check: false).returncode() != 0
             error('Manpage style sheet cannot be found (package docbook-xsl missing)')
         endif
     endif
@@ -25,7 +25,7 @@ if want_man or want_html
     # docbooks = [ ['file1', 'manvolnum-from-file1.xml', 'file1.xml'],
     #              ['file2', 'manvolnum-from-file2.xml', 'file2.xml'], ... ]
     docbooks = []
-    rr = run_command(docbklst)
+    rr = run_command(docbklst, check: false)
     output = rr.stdout().strip()
     if output != ''
         foreach item : output.split(';')

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ if check_pymodules
         py_modules_reqd += [['lxml', 'Install python3-lxml (deb/rpm)']]
     endif
     foreach p : py_modules_reqd
-        if run_command(python3, '-c', 'import @0@'.format(p[0])).returncode() != 0
+        if run_command(python3, '-c', 'import @0@'.format(p[0]), check: false).returncode() != 0
             error('Required python3 module "@0@" not found. @1@'.format(p[0], p[1]))
         endif
     endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,7 +26,7 @@ if modules_to_lint.length() != 0
     pyflakes = find_program('pyflakes3', required: false)
     if not pyflakes.found()
         temp = find_program('pyflakes', required: false)
-        if temp.found() and run_command(temp, '--version').stdout().contains('Python 3')
+        if temp.found() and run_command(temp, '--version', check: false).stdout().contains('Python 3')
             pyflakes = temp
         endif
     endif


### PR DESCRIPTION
Per meson documentation, the default value for the run_command()
'check' parameter will be changed from 'false' to 'true' in a
future release of meson. To avoid problems when that change
happens, we explicitly use 'check: false' when invoking
run_command().

Signed-off-by: Martin Belanger <martin.belanger@dell.com>