### PR TITLE
build: install staslib as pure

### DIFF
--- a/staslib/meson.build
+++ b/staslib/meson.build
@@ -30,7 +30,7 @@ endforeach
 files_to_install = copied_files + configured_files
 python3.install_sources(
     files_to_install,
-    pure: false,
+    pure: true,
     subdir: 'staslib',
 )
 


### PR DESCRIPTION
in staslib/meson.build, use "pure: true" with install_sources()

Signed-off-by: Martin Belanger <martin.belanger@dell.com>