### PR TITLE
build: install staslib as pure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # STorage Appliance Services (STAS)
 
+## Changes with release 1.0.1
+
+- Install staslib as pure python package instead of arch-specific.
+
 ## Changes with release 1.0
 
 - First public release following TP8009 / TP8010 ratification and publication.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@ copyright = 'Copyright (c) 2022, Dell Inc. or its subsidiaries.  All rights rese
 author = 'Martin Belanger <martin.belanger@dell.com>'
 master_doc = 'index'
 
-release = '1.0'
+release = '1.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 project(
     'nvme-stas',
     meson_version: '>= 0.53.0',
-    version: '1.0',
+    version: '1.0.1',
     license: 'Apache-2.0',
     default_options: [
         'buildtype=release',

--- a/staslib/meson.build
+++ b/staslib/meson.build
@@ -30,7 +30,7 @@ endforeach
 files_to_install = copied_files + configured_files
 python3.install_sources(
     files_to_install,
-    pure: false,
+    pure: true,
     subdir: 'staslib',
 )
 


### PR DESCRIPTION
In staslib/meson.build, use "pure: true" with install_sources().
Also, bump version from 1.0 to 1.0.1.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>