### PR TITLE
stacd: allow disabling nvme-cli auto-connect udev rule.

### DIFF
--- a/etc/stas/stacd.conf
+++ b/etc/stas/stacd.conf
@@ -98,6 +98,31 @@
 #            Default: ipv4+ipv6
 #ip-family=ipv4+ipv6
 
+# udev-rule: nvme-cli uses a udev rule to tell udevd to automatically invoke the
+#            "nvme connect" command to connect to I/O Controllers (IOC) when an
+#            AEN indicating a change of Discovery Log Page Entries (DLPE) is
+#            received.
+#
+#            Using udevd in this way creates a race condition with stafd/stacd
+#            that also reacts to AENs by retrieving the DLPEs and connecting to
+#            IOCs. This is not a critical issue. It's only annoying because we
+#            may get error messages in the syslog as a result of the race
+#            condition. However, all connections are successful and stacd will
+#            eventually realize that the connections succeeded.
+#
+#            This parameter allows disabling nvme-cli's udev rule. By doing
+#            this, stafd/stacd will now be the only processes responding to AENs
+#            indicating a change of DPLEs. Commands such as nvme-cli's
+#            "nvme connect-all" will still be functional, but only stafd/stacd
+#            (and not udevd) will retrieve the DPLEs and establish IOC
+#            connections. The default, enabled, means that nvme-cli's udev rule
+#            is enabled and the race condition with stafd/stacd can occur.
+#
+#           Type:    String
+#           Range:   [disabled, enabled]
+#           Default: enabled
+#udev-rule=enabled
+
 [Controllers]
 # controller: I/O Controllers (IOC) are specified with this keyword.
 #


### PR DESCRIPTION
nvme-cli installs a udev rule (70-nvmf-autoconnect.rules) that is
used to automatically connect to I/O Controllers (IOC) as a result
of receiving an AEN indicating a change of Discovery Log Page
Entries (DLPE) from a Discovery Controller.

This udev rule creates a race condition with stafd/stacd who also
react to AENs to automatically connect to IOCs. This is not a
critical problem since the connections are successful and stacd is
designed to handle potential race conditions. However, error
messages may get printed to the syslog even though everything is
working fine.

This patch allows disabling the udev rule to eliminate the race
condition. The default is to leave the udev rule active and allow
for the race condition to happen. If a user gets annoyed by the
false error messages, they can configure stacd.conf to disable the
udev rule.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>