### PR TITLE
staslib: better handling and clean up of singleton objects.

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -290,7 +290,7 @@ PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-udev.py
 PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-version.py
 PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-transport_id.py
 PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-config.py
-PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-nvme_options.py
+sudo PYTHONPATH=${PYTHON_PATH} coverage run --rcfile=.coveragerc ../test/test-nvme_options.py
 
 ################################################################################
 # Stop nvme target simulator

--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -81,8 +81,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
     protocol_as_string = lambda proto: Avahi.protos.get(proto, 'unknown')
 
     # ==========================================================================
-    def __init__(self, logger, sysbus, change_cb):
-        self._logger = logger
+    def __init__(self, sysbus, change_cb):
         self._change_cb = change_cb
         self._services = dict()
         self._sysbus = sysbus
@@ -140,7 +139,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
 
     def kill(self):
         '''@brief Clean up object'''
-        self._logger.debug('Avahi.kill()')
+        stas.LOG.debug('Avahi.kill()')
 
         self._kick_avahi_tmr.kill()
         self._kick_avahi_tmr = None
@@ -219,7 +218,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         self._kick_avahi_tmr.clear()
 
     def _disconnect(self):
-        self._logger.debug('Avahi._disconnect()')
+        stas.LOG.debug('Avahi._disconnect()')
         for service in self._services.values():
             resolver = service.pop('resolver', None)
             if resolver is not None:
@@ -227,7 +226,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                     resolver.Free()
                     dasbus.client.proxy.disconnect_proxy(resolver)
                 except (AttributeError, dasbus.error.DBusError) as ex:
-                    self._logger.debug('Avahi._disconnect()                - Failed to Free() resolver. %s', ex)
+                    stas.LOG.debug('Avahi._disconnect()                - Failed to Free() resolver. %s', ex)
 
         self._services = dict()
 
@@ -236,7 +235,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                 browser.Free()
                 dasbus.client.proxy.disconnect_proxy(browser)
             except (AttributeError, dasbus.error.DBusError) as ex:
-                self._logger.debug('Avahi._disconnect()                - Failed to Free() browser. %s', ex)
+                stas.LOG.debug('Avahi._disconnect()                - Failed to Free() browser. %s', ex)
 
         self._service_browsers = dict()
 
@@ -252,14 +251,14 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
 
     def _avahi_available(self, _avahi_watcher):
         '''@brief Hook up DBus signal handlers for signals from stafd.'''
-        self._logger.info('avahi-daemon service available, zeroconf supported.')
+        stas.LOG.info('avahi-daemon service available, zeroconf supported.')
         success = self._configure_browsers()
         if not success:
             self._kick_avahi_tmr.start()
 
     def _avahi_unavailable(self, _avahi_watcher):
         self._disconnect()
-        self._logger.warning('avahi-daemon not available, zeroconf not supported.')
+        stas.LOG.warning('avahi-daemon not available, zeroconf not supported.')
         self._kick_avahi_tmr.start()
 
     def _configure_browsers(self):
@@ -267,8 +266,8 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         stypes_to_add = self._stypes - stypes_cur
         stypes_to_rm = stypes_cur - self._stypes
 
-        self._logger.debug('Avahi._configure_browsers()        - stypes_to_rm  = %s', list(stypes_to_rm))
-        self._logger.debug('Avahi._configure_browsers()        - stypes_to_add = %s', list(stypes_to_add))
+        stas.LOG.debug('Avahi._configure_browsers()        - stypes_to_rm  = %s', list(stypes_to_rm))
+        stas.LOG.debug('Avahi._configure_browsers()        - stypes_to_add = %s', list(stypes_to_add))
 
         for stype_to_rm in stypes_to_rm:
             browser = self._service_browsers.pop(stype_to_rm, None)
@@ -277,7 +276,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                     browser.Free()
                     dasbus.client.proxy.disconnect_proxy(browser)
                 except (AttributeError, dasbus.error.DBusError) as ex:
-                    self._logger.debug('Avahi._configure_browsers()        - Failed to Free() browser. %s', ex)
+                    stas.LOG.debug('Avahi._configure_browsers()        - Failed to Free() browser. %s', ex)
 
             # Find the cached services corresponding to stype_to_rm and remove them
             services_to_rm = [service for service in self._services if service[3] == stype_to_rm]
@@ -288,7 +287,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                         resolver.Free()
                         dasbus.client.proxy.disconnect_proxy(resolver)
                     except (AttributeError, dasbus.error.DBusError) as ex:
-                        self._logger.debug('Avahi._configure_browsers()        - Failed to Free() resolver. %s', ex)
+                        stas.LOG.debug('Avahi._configure_browsers()        - Failed to Free() resolver. %s', ex)
 
         for stype in stypes_to_add:
             try:
@@ -297,8 +296,8 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                 )
                 self._service_browsers[stype] = self._sysbus.get_proxy(Avahi.DBUS_NAME, obj_path)
             except dasbus.error.DBusError as ex:
-                self._logger.debug('Avahi._configure_browsers()        - Failed to contact avahi-daemon. %s', ex)
-                self._logger.warning('avahi-daemon not available, operating w/o mDNS discovery.')
+                stas.LOG.debug('Avahi._configure_browsers()        - Failed to contact avahi-daemon. %s', ex)
+                stas.LOG.warning('avahi-daemon not available, operating w/o mDNS discovery.')
                 return False
 
         return True
@@ -314,7 +313,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         *_user_data
     ):
         (interface, protocol, name, stype, domain, flags) = args
-        self._logger.debug(
+        stas.LOG.debug(
             'Avahi._service_discovered()        - interface=%s (%s), protocol=%s, stype=%s, domain=%s, flags=%s %-14s name=%s',
             interface,
             socket.if_indextoname(interface),
@@ -337,7 +336,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                     'data': {},
                 }
             except dasbus.error.DBusError as ex:
-                self._logger.warning('Failed to create resolver: "%s", "%s", "%s". %s', interface, name, stype, ex)
+                stas.LOG.warning('Failed to create resolver: "%s", "%s", "%s". %s', interface, name, stype, ex)
 
     def _service_removed(
         self,
@@ -350,7 +349,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         *_user_data
     ):
         (interface, protocol, name, stype, domain, flags) = args
-        self._logger.debug(
+        stas.LOG.debug(
             'Avahi._service_removed()           - interface=%s (%s), protocol=%s, stype=%s, domain=%s, flags=%s %-14s name=%s',
             interface,
             socket.if_indextoname(interface),
@@ -369,7 +368,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                 resolver.Free()
                 dasbus.client.proxy.disconnect_proxy(resolver)
             except (AttributeError, dasbus.error.DBusError) as ex:
-                self._logger.debug('Avahi._service_removed()           - Failed to Free() resolver. %s', ex)
+                stas.LOG.debug('Avahi._service_removed()           - Failed to Free() resolver. %s', ex)
 
         self._change_cb()
 
@@ -385,7 +384,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
     ):
         (interface, protocol, name, stype, domain, host, aprotocol, address, port, txt, flags) = args
         txt = txt2dict(txt)
-        self._logger.debug(
+        stas.LOG.debug(
             'Avahi._service_identified()        - interface=%s (%s), protocol=%s, stype=%s, domain=%s, flags=%s %-14s name=%s, host=%s, aprotocol=%s, address=%s, port=%s, txt=%s',
             interface,
             socket.if_indextoname(interface),
@@ -410,12 +409,12 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
                 'trsvcid':    str(port),
                 'host-iface': socket.if_indextoname(interface),
                 'subsysnqn':  txt.get('NQN', 'nqn.2014-08.org.nvmexpress.discovery')
-                              if stas.get_nvme_options().discovery_supp
+                              if stas.NvmeOptions().discovery_supp
                               else 'nqn.2014-08.org.nvmexpress.discovery',
             }
         self._change_cb()
 
-    def _failure_handler(
+    def _failure_handler(  # pylint: disable=no-self-use
         self,
         _connection,
         _sender_name: str,
@@ -426,5 +425,6 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         *_user_data
     ):
         (error,) = args
-        if 'ServiceResolver' not in interface_name or 'TimeoutError' not in error:  # ServiceResolver may fire a timeout event after being Free'd(). This seems to be normal.
-            self._logger.error('Avahi._failure_handler()    - name=%s, error=%s', interface_name, error)
+        if 'ServiceResolver' not in interface_name or 'TimeoutError' not in error:
+            # ServiceResolver may fire a timeout event after being Free'd(). This seems to be normal.
+            stas.LOG.error('Avahi._failure_handler()    - name=%s, error=%s', interface_name, error)

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -33,7 +33,8 @@ if __name__ == '__main__':
 
         def test_config(self):
             '''Check we can read the temporary configuration file'''
-            cnf = stas.get_configuration(StasProcessConfUnitTest.FNAME)
+            cnf = stas.Configuration()
+            cnf.conf_file = StasProcessConfUnitTest.FNAME
             self.assertEqual(cnf.conf_file, StasProcessConfUnitTest.FNAME)
             self.assertTrue(cnf.tron)
             self.assertFalse(cnf.hdr_digest)
@@ -84,7 +85,9 @@ if __name__ == '__main__':
 
         def test_config(self):
             '''Check we can read the temporary configuration file'''
-            cnf = stas.SysConfiguration(StasSysConfUnitTest.FNAME)
+            cnf = stas.SysConfiguration()
+            cnf.conf_file = StasSysConfUnitTest.FNAME
+            self.assertEqual(cnf.conf_file, StasSysConfUnitTest.FNAME)
             self.assertEqual(cnf.hostnqn, StasSysConfUnitTest.NQN)
             self.assertEqual(cnf.hostid, StasSysConfUnitTest.ID)
             self.assertEqual(cnf.hostsymname, StasSysConfUnitTest.SYMNAME)

--- a/test/test-nvme_options.py
+++ b/test/test-nvme_options.py
@@ -12,8 +12,7 @@ if __name__ == '__main__':
             super().__init__(*args, **kwargs)
             self.is_root = os.geteuid() == 0
             if self.is_root:  # Only root can access /dev/nvme-fabrics
-                stas.get_logger(False, 'Test')
-                self.nvme_options = stas.get_nvme_options()
+                self.nvme_options = stas.NvmeOptions()
             else:
                 self.nvme_options = None
 
@@ -26,5 +25,8 @@ if __name__ == '__main__':
             '''Test host_iface_supp'''
             if self.nvme_options:
                 self.assertEqual(type(self.nvme_options.host_iface_supp), bool)
+
+        def test_str(self):
+            self.assertIsInstance(str(self.nvme_options), str)
 
     unittest.main()

--- a/test/test-transport_id.py
+++ b/test/test-transport_id.py
@@ -17,7 +17,6 @@ if __name__ == '__main__':
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.cnf = stas.get_configuration('/dev/null')
             self.cid = {
                 'transport':   Test.TRANSPORT,
                 'traddr':      Test.TRADDR,

--- a/test/test-udev.py
+++ b/test/test-udev.py
@@ -10,10 +10,12 @@ if __name__ == '__main__':
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            stas.get_logger(False, 'Test')
 
         def test_get_device(self):
             dev = stas.UDEV.get_nvme_device('null')
             self.assertEqual(dev.device_node, '/dev/null')
+
+        def test_get_bad_device(self):
+            self.assertIsNone(stas.UDEV.get_nvme_device('bozo'))
 
     unittest.main()


### PR DESCRIPTION
Coverage testing identified that atexit does not invoke clean up
methods for singleton objects on exit. Refactored singleton code
and added clean up methods that get explicitly called on exit.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>