### PR TITLE
stacd: 'NoneType' object has no attribute 'set_timeout'

### DIFF
--- a/stacd.py
+++ b/stacd.py
@@ -322,7 +322,7 @@ class Stac(stas.Service):
         except dasbus.error.DBusError:
             stas.LOG.error('Failed to connect to staf')
 
-    def _destroy_staf_comlink(self, watcher):
+    def _destroy_staf_comlink(self, watcher):  # pylint: disable=unused-argument
         if self._staf:
             self._staf.log_pages_changed.disconnect(self._log_pages_changed)
             dasbus.client.proxy.disconnect_proxy(self._staf)


### PR DESCRIPTION
bug fix during object clean up. self._cfg_soak_tmr could be None.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>