### PR TITLE
test: change if name guardian to allow manual test execution

### DIFF
--- a/test/test-config.py
+++ b/test/test-config.py
@@ -3,95 +3,97 @@ import os
 import unittest
 from staslib import stas
 
+
+class StasProcessConfUnitTest(unittest.TestCase):
+    '''Process config unit tests'''
+
+    FNAME = '/tmp/stas-process-config-test'
+
+    @classmethod
+    def setUpClass(cls):
+        '''Create a temporary configuration file'''
+        conf = [
+            '[Global]\n',
+            'tron=true\n',
+            'kato=200\n',
+            'ip-family=ipv6\n',
+            '[Controllers]\n',
+            'controller=transport=tcp;traddr=100.100.100.100;host-iface=enp0s8\n',
+            'blacklist=transport=tcp;traddr=10.10.10.10\n',
+        ]
+        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+            f.writelines(conf)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Delete the temporary configuration file'''
+        if os.path.exists(StasProcessConfUnitTest.FNAME):
+            os.remove(StasProcessConfUnitTest.FNAME)
+
+    def test_config(self):
+        '''Check we can read the temporary configuration file'''
+        cnf = stas.Configuration()
+        cnf.conf_file = StasProcessConfUnitTest.FNAME
+        self.assertEqual(cnf.conf_file, StasProcessConfUnitTest.FNAME)
+        self.assertTrue(cnf.tron)
+        self.assertFalse(cnf.hdr_digest)
+        self.assertFalse(cnf.data_digest)
+        self.assertTrue(cnf.persistent_connections)
+        self.assertTrue(cnf.udev_rule_enabled)
+        self.assertFalse(cnf.sticky_connections)
+        self.assertFalse(cnf.ignore_iface)
+        self.assertIn(6, cnf.ip_family)
+        self.assertNotIn(4, cnf.ip_family)
+        self.assertEqual(cnf.kato, 200)
+        self.assertEqual(
+            cnf.get_controllers(),
+            [
+                {'transport': 'tcp', 'traddr': '100.100.100.100', 'host-iface': 'enp0s8'},
+            ],
+        )
+
+        self.assertEqual(cnf.get_blacklist(), [{'transport': 'tcp', 'traddr': '10.10.10.10'}])
+
+        self.assertEqual(cnf.get_stypes(), ['_nvme-disc._tcp'])
+
+        self.assertTrue(cnf.zeroconf_enabled())
+
+
+class StasSysConfUnitTest(unittest.TestCase):
+    '''Sys config unit tests'''
+
+    FNAME = '/tmp/stas-sys-config-test'
+    NQN = 'nqn.2014-08.org.nvmexpress:uuid:9aae2691-b275-4b64-8bfe-5da429a2bab9'
+    ID = '56529e15-0f3e-4ede-87e2-63932a4adb99'
+    SYMNAME = 'Bart-Simpson'
+
+    @classmethod
+    def setUpClass(cls):
+        '''Create a temporary configuration file'''
+        conf = [
+            '[Host]\n',
+            f'nqn={StasSysConfUnitTest.NQN}\n',
+            f'id={StasSysConfUnitTest.ID}\n',
+            f'symname={StasSysConfUnitTest.SYMNAME}\n',
+        ]
+        with open(StasSysConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+            f.writelines(conf)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Delete the temporary configuration file'''
+        if os.path.exists(StasSysConfUnitTest.FNAME):
+            os.remove(StasSysConfUnitTest.FNAME)
+
+    def test_config(self):
+        '''Check we can read the temporary configuration file'''
+        cnf = stas.SysConfiguration()
+        cnf.conf_file = StasSysConfUnitTest.FNAME
+        self.assertEqual(cnf.conf_file, StasSysConfUnitTest.FNAME)
+        self.assertEqual(cnf.hostnqn, StasSysConfUnitTest.NQN)
+        self.assertEqual(cnf.hostid, StasSysConfUnitTest.ID)
+        self.assertEqual(cnf.hostsymname, StasSysConfUnitTest.SYMNAME)
+
+
 if __name__ == '__main__':
-
-    class StasProcessConfUnitTest(unittest.TestCase):
-        '''Process config unit tests'''
-
-        FNAME = '/tmp/stas-process-config-test'
-
-        @classmethod
-        def setUpClass(cls):
-            '''Create a temporary configuration file'''
-            conf = [
-                '[Global]\n',
-                'tron=true\n',
-                'kato=200\n',
-                'ip-family=ipv6\n',
-                '[Controllers]\n',
-                'controller=transport=tcp;traddr=100.100.100.100;host-iface=enp0s8\n',
-                'blacklist=transport=tcp;traddr=10.10.10.10\n',
-            ]
-            with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
-                f.writelines(conf)
-
-        @classmethod
-        def tearDownClass(cls):
-            '''Delete the temporary configuration file'''
-            if os.path.exists(StasProcessConfUnitTest.FNAME):
-                os.remove(StasProcessConfUnitTest.FNAME)
-
-        def test_config(self):
-            '''Check we can read the temporary configuration file'''
-            cnf = stas.Configuration()
-            cnf.conf_file = StasProcessConfUnitTest.FNAME
-            self.assertEqual(cnf.conf_file, StasProcessConfUnitTest.FNAME)
-            self.assertTrue(cnf.tron)
-            self.assertFalse(cnf.hdr_digest)
-            self.assertFalse(cnf.data_digest)
-            self.assertTrue(cnf.persistent_connections)
-            self.assertTrue(cnf.udev_rule_enabled)
-            self.assertFalse(cnf.sticky_connections)
-            self.assertFalse(cnf.ignore_iface)
-            self.assertIn(6, cnf.ip_family)
-            self.assertNotIn(4, cnf.ip_family)
-            self.assertEqual(cnf.kato, 200)
-            self.assertEqual(
-                cnf.get_controllers(),
-                [
-                    {'transport': 'tcp', 'traddr': '100.100.100.100', 'host-iface': 'enp0s8'},
-                ],
-            )
-
-            self.assertEqual(cnf.get_blacklist(), [{'transport': 'tcp', 'traddr': '10.10.10.10'}])
-
-            self.assertEqual(cnf.get_stypes(), ['_nvme-disc._tcp'])
-
-            self.assertTrue(cnf.zeroconf_enabled())
-
-    class StasSysConfUnitTest(unittest.TestCase):
-        '''Sys config unit tests'''
-
-        FNAME = '/tmp/stas-sys-config-test'
-        NQN = 'nqn.2014-08.org.nvmexpress:uuid:9aae2691-b275-4b64-8bfe-5da429a2bab9'
-        ID = '56529e15-0f3e-4ede-87e2-63932a4adb99'
-        SYMNAME = 'Bart-Simpson'
-
-        @classmethod
-        def setUpClass(cls):
-            '''Create a temporary configuration file'''
-            conf = [
-                '[Host]\n',
-                f'nqn={StasSysConfUnitTest.NQN}\n',
-                f'id={StasSysConfUnitTest.ID}\n',
-                f'symname={StasSysConfUnitTest.SYMNAME}\n',
-            ]
-            with open(StasSysConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
-                f.writelines(conf)
-
-        @classmethod
-        def tearDownClass(cls):
-            '''Delete the temporary configuration file'''
-            if os.path.exists(StasSysConfUnitTest.FNAME):
-                os.remove(StasSysConfUnitTest.FNAME)
-
-        def test_config(self):
-            '''Check we can read the temporary configuration file'''
-            cnf = stas.SysConfiguration()
-            cnf.conf_file = StasSysConfUnitTest.FNAME
-            self.assertEqual(cnf.conf_file, StasSysConfUnitTest.FNAME)
-            self.assertEqual(cnf.hostnqn, StasSysConfUnitTest.NQN)
-            self.assertEqual(cnf.hostid, StasSysConfUnitTest.ID)
-            self.assertEqual(cnf.hostsymname, StasSysConfUnitTest.SYMNAME)
-
     unittest.main()

--- a/test/test-transport_id.py
+++ b/test/test-transport_id.py
@@ -2,87 +2,88 @@
 import unittest
 from staslib import stas
 
+
+class Test(unittest.TestCase):
+    '''Unit test for class TransportId'''
+
+    TRANSPORT = 'tcp'
+    TRADDR = '10.10.10.10'
+    OTHER_TRADDR = '1.1.1.1'
+    SUBSYSNQN = 'nqn.1988-11.com.dell:SFSS:2:20220208134025e8'
+    TRSVCID = '8009'
+    HOST_TRADDR = '1.2.3.4'
+    HOST_IFACE = 'wlp0s20f3'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cid = {
+            'transport': Test.TRANSPORT,
+            'traddr': Test.TRADDR,
+            'subsysnqn': Test.SUBSYSNQN,
+            'trsvcid': Test.TRSVCID,
+            'host-traddr': Test.HOST_TRADDR,
+            'host-iface': Test.HOST_IFACE,
+        }
+        self.other_cid = {
+            'transport': Test.TRANSPORT,
+            'traddr': Test.OTHER_TRADDR,
+            'subsysnqn': Test.SUBSYSNQN,
+            'trsvcid': Test.TRSVCID,
+            'host-traddr': Test.HOST_TRADDR,
+            'host-iface': Test.HOST_IFACE,
+        }
+
+        self.tid = stas.TransportId(self.cid)
+        self.other_tid = stas.TransportId(self.other_cid)
+
+    def test_key(self):
+        '''Check that a key exists'''
+        self.assertIsInstance(self.tid.key, tuple)
+
+    def test_hash(self):
+        '''Check that a hash exists'''
+        self.assertIsInstance(self.tid.hash, int)
+
+    def test_transport(self):
+        '''Check that transport is set'''
+        self.assertEqual(self.tid.transport, Test.TRANSPORT)
+
+    def test_traddr(self):
+        '''Check that traddr is set'''
+        self.assertEqual(self.tid.traddr, Test.TRADDR)
+
+    def test_trsvcid(self):
+        '''Check that trsvcid is set'''
+        self.assertEqual(self.tid.trsvcid, Test.TRSVCID)
+
+    def test_host_traddr(self):
+        '''Check that host_traddr is set'''
+        self.assertEqual(self.tid.host_traddr, Test.HOST_TRADDR)
+
+    def test_host_iface(self):
+        '''Check that host_iface is set'''
+        self.assertEqual(self.tid.host_iface, Test.HOST_IFACE)
+
+    def test_subsysnqn(self):
+        '''Check that subsysnqn is set'''
+        self.assertEqual(self.tid.subsysnqn, Test.SUBSYSNQN)
+
+    def test_as_dict(self):
+        '''Check that a TransportId can be converted back to the original Dict it was created with'''
+        self.assertDictEqual(self.tid.as_dict(), self.cid)
+
+    def test_str(self):
+        '''Check that a TransportId can be represented as a string'''
+        self.assertTrue(str(self.tid).startswith(f'({Test.TRANSPORT},'))
+
+    def test_eq(self):
+        '''Check that two TransportId objects can be tested for equality'''
+        self.assertEqual(self.tid, stas.TransportId(self.cid))
+
+    def test_ne(self):
+        '''Check that two TransportId objects can be tested for non-equality'''
+        self.assertNotEqual(self.tid, self.other_tid)
+
+
 if __name__ == '__main__':
-
-    class Test(unittest.TestCase):
-        '''Unit test for class TransportId'''
-
-        TRANSPORT    = 'tcp'
-        TRADDR       = '10.10.10.10'
-        OTHER_TRADDR = '1.1.1.1'
-        SUBSYSNQN    = 'nqn.1988-11.com.dell:SFSS:2:20220208134025e8'
-        TRSVCID      = '8009'
-        HOST_TRADDR  = '1.2.3.4'
-        HOST_IFACE   = 'wlp0s20f3'
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.cid = {
-                'transport':   Test.TRANSPORT,
-                'traddr':      Test.TRADDR,
-                'subsysnqn':   Test.SUBSYSNQN,
-                'trsvcid':     Test.TRSVCID,
-                'host-traddr': Test.HOST_TRADDR,
-                'host-iface':  Test.HOST_IFACE,
-            }
-            self.other_cid = {
-                'transport':   Test.TRANSPORT,
-                'traddr':      Test.OTHER_TRADDR,
-                'subsysnqn':   Test.SUBSYSNQN,
-                'trsvcid':     Test.TRSVCID,
-                'host-traddr': Test.HOST_TRADDR,
-                'host-iface':  Test.HOST_IFACE,
-            }
-
-            self.tid = stas.TransportId(self.cid)
-            self.other_tid = stas.TransportId(self.other_cid)
-
-        def test_key(self):
-            '''Check that a key exists'''
-            self.assertIsInstance(self.tid.key, tuple)
-
-        def test_hash(self):
-            '''Check that a hash exists'''
-            self.assertIsInstance(self.tid.hash, int)
-
-        def test_transport(self):
-            '''Check that transport is set'''
-            self.assertEqual(self.tid.transport, Test.TRANSPORT)
-
-        def test_traddr(self):
-            '''Check that traddr is set'''
-            self.assertEqual(self.tid.traddr, Test.TRADDR)
-
-        def test_trsvcid(self):
-            '''Check that trsvcid is set'''
-            self.assertEqual(self.tid.trsvcid, Test.TRSVCID)
-
-        def test_host_traddr(self):
-            '''Check that host_traddr is set'''
-            self.assertEqual(self.tid.host_traddr, Test.HOST_TRADDR)
-
-        def test_host_iface(self):
-            '''Check that host_iface is set'''
-            self.assertEqual(self.tid.host_iface, Test.HOST_IFACE)
-
-        def test_subsysnqn(self):
-            '''Check that subsysnqn is set'''
-            self.assertEqual(self.tid.subsysnqn, Test.SUBSYSNQN)
-
-        def test_as_dict(self):
-            '''Check that a TransportId can be converted back to the original Dict it was created with'''
-            self.assertDictEqual(self.tid.as_dict(), self.cid)
-
-        def test_str(self):
-            '''Check that a TransportId can be represented as a string'''
-            self.assertTrue(str(self.tid).startswith(f'({Test.TRANSPORT},'))
-
-        def test_eq(self):
-            '''Check that two TransportId objects can be tested for equality'''
-            self.assertEqual(self.tid, stas.TransportId(self.cid))
-
-        def test_ne(self):
-            '''Check that two TransportId objects can be tested for non-equality'''
-            self.assertNotEqual(self.tid, self.other_tid)
-
     unittest.main()

--- a/test/test-udev.py
+++ b/test/test-udev.py
@@ -3,19 +3,20 @@ import os
 import unittest
 from staslib import stas
 
+
+class Test(unittest.TestCase):
+    '''Unit tests for class Udev'''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def test_get_device(self):
+        dev = stas.UDEV.get_nvme_device('null')
+        self.assertEqual(dev.device_node, '/dev/null')
+
+    def test_get_bad_device(self):
+        self.assertIsNone(stas.UDEV.get_nvme_device('bozo'))
+
+
 if __name__ == '__main__':
-
-    class Test(unittest.TestCase):
-        '''Unit tests for class Udev'''
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-        def test_get_device(self):
-            dev = stas.UDEV.get_nvme_device('null')
-            self.assertEqual(dev.device_node, '/dev/null')
-
-        def test_get_bad_device(self):
-            self.assertIsNone(stas.UDEV.get_nvme_device('bozo'))
-
     unittest.main()

--- a/test/test-version.py
+++ b/test/test-version.py
@@ -2,44 +2,45 @@
 import unittest
 from staslib.version import KernelVersion
 
+
+class VersionUnitTests(unittest.TestCase):
+    '''Unit tests for class KernelVersion'''
+
+    version = KernelVersion('5.8.0-63-generic')
+
+    def test_str(self):
+        self.assertIsInstance(str(self.version), str)
+
+    def test_repr(self):
+        self.assertIsInstance(repr(self.version), str)
+
+    def test_eq(self):
+        '''Test equality'''
+        self.assertEqual(self.version, '5.8.0-63')
+        self.assertNotEqual(self.version, '5.8.0')
+
+    def test_lt(self):
+        '''Test lower than'''
+        self.assertTrue(self.version < '5.9')
+        self.assertFalse(self.version < '5.7')
+
+    def test_le(self):
+        '''Test lower equal'''
+        self.assertTrue(self.version <= '5.8.0-63')
+        self.assertTrue(self.version <= '5.8.1')
+        self.assertFalse(self.version <= '5.7')
+
+    def test_gt(self):
+        '''Test greater than'''
+        self.assertTrue(self.version > '5.8')
+        self.assertFalse(self.version > '5.9')
+
+    def test_ge(self):
+        '''Test greater equal'''
+        self.assertTrue(self.version >= '5.8.0-63')
+        self.assertTrue(self.version >= '5.7.0')
+        self.assertFalse(self.version >= '5.9')
+
+
 if __name__ == '__main__':
-
-    class VersionUnitTests(unittest.TestCase):
-        '''Unit tests for class KernelVersion'''
-
-        version = KernelVersion('5.8.0-63-generic')
-
-        def test_str(self):
-            self.assertIsInstance(str(self.version), str)
-
-        def test_repr(self):
-            self.assertIsInstance(repr(self.version), str)
-
-        def test_eq(self):
-            '''Test equality'''
-            self.assertEqual(self.version, '5.8.0-63')
-            self.assertNotEqual(self.version, '5.8.0')
-
-        def test_lt(self):
-            '''Test lower than'''
-            self.assertTrue(self.version < '5.9')
-            self.assertFalse(self.version < '5.7')
-
-        def test_le(self):
-            '''Test lower equal'''
-            self.assertTrue(self.version <= '5.8.0-63')
-            self.assertTrue(self.version <= '5.8.1')
-            self.assertFalse(self.version <= '5.7')
-
-        def test_gt(self):
-            '''Test greater than'''
-            self.assertTrue(self.version > '5.8')
-            self.assertFalse(self.version > '5.9')
-
-        def test_ge(self):
-            '''Test greater equal'''
-            self.assertTrue(self.version >= '5.8.0-63')
-            self.assertTrue(self.version >= '5.7.0')
-            self.assertFalse(self.version >= '5.9')
-
     unittest.main()


### PR DESCRIPTION
## please review with 'ignore whitespaces' option

example:
```
$ LD_LIBRARY_PATH=.build/subprojects/libnvme/src python3 -m unittest test/*.py
.................Udev.get_nvme_device() - Error: [Errno 2] No such file or directory: '/dev/bozo'
.........
----------------------------------------------------------------------
Ran 26 tests in 0.004s

OK
```
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>