### PR TITLE
staslib: calling wrong cback function on controller removal.

### DIFF
--- a/stacd.py
+++ b/stacd.py
@@ -349,7 +349,7 @@ class Stac(stas.Service):
         for tid in controllers_to_del:
             controller = self._controllers.pop(tid, None)
             if controller is not None:
-                controller.disconnect(self._on_ctrl_disconnected, stas.CNF.sticky_connections)
+                controller.disconnect(self.remove_controller, stas.CNF.sticky_connections)
 
         for tid in controllers_to_add:
             self._controllers[tid] = Ioc(tid)

--- a/stafd.py
+++ b/stafd.py
@@ -575,7 +575,7 @@ class Staf(stas.Service):
         for tid in controllers_to_del:
             controller = self._controllers.pop(tid, None)
             if controller is not None:
-                controller.disconnect(self._on_ctrl_disconnected, stas.CNF.persistent_connections)
+                controller.disconnect(self.remove_controller, stas.CNF.persistent_connections)
 
         for tid in controllers_to_add:
             self._controllers[tid] = Dc(tid)


### PR DESCRIPTION
There are two cback functions that can be called when a controller
is removed. One of which is only meant to be called on process
shutdown when disconnecting from all controllers. The other cback
is meant to be called during normaln operation when we need to
disconnect from a single controller. We were calling the wrong
cback during normal disconnect, which led the process to think we
were shutting down.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>