### PR TITLE
install: add service to auto-generate hostnqn and hostid if missing

### DIFF
--- a/usr/lib/systemd/system/meson.build
+++ b/usr/lib/systemd/system/meson.build
@@ -11,13 +11,27 @@ sd_service_file_dir = join_paths(prefix, 'lib', 'systemd', 'system')
 configure_file(
     input: 'stafd.in.service',
     output: 'stafd.service',
-    configuration: conf,
     install_dir: sd_service_file_dir,
+    configuration: conf,
 )
 
 configure_file(
     input: 'stacd.in.service',
     output: 'stacd.service',
-    configuration: conf,
     install_dir: sd_service_file_dir,
+    configuration: conf,
+)
+
+configure_file(
+    input: 'stas-config@.service',
+    output: 'stas-config@.service',
+    install_dir: sd_service_file_dir,
+    copy: true,
+)
+
+configure_file(
+    input: 'stas-config.in.target',
+    output: 'stas-config.target',
+    install_dir: sd_service_file_dir,
+    configuration: conf,
 )

--- a/usr/lib/systemd/system/stacd.in.service
+++ b/usr/lib/systemd/system/stacd.in.service
@@ -7,8 +7,10 @@
 [Unit]
 Description=@STAC_DESCRIPTION@ (@STAC_ACRONYM@)
 Documentation=man:@STACD_PROCNAME@.service(8) man:@STACD_PROCNAME@(8)
-After=modprobe@nvme_tcp.service network.target
 Wants=modprobe@nvme_tcp.service network.target
+After=modprobe@nvme_tcp.service network.target
+Wants=stas-config.target
+After=stas-config.target
 
 # Check that the nvme-tcp kernel module was previously
 # loaded by checking for the presence of /dev/nvme-fabrics.

--- a/usr/lib/systemd/system/stafd.in.service
+++ b/usr/lib/systemd/system/stafd.in.service
@@ -10,8 +10,10 @@
 [Unit]
 Description=@STAF_DESCRIPTION@ (@STAF_ACRONYM@)
 Documentation=man:@STAFD_PROCNAME@.service(8) man:@STAFD_PROCNAME@(8)
-After=modprobe@nvme_tcp.service network.target avahi-daemon.service
 Wants=modprobe@nvme_tcp.service network.target
+After=modprobe@nvme_tcp.service network.target avahi-daemon.service
+Wants=stas-config.target
+After=stas-config.target
 
 # Check that the nvme-tcp kernel module was previously
 # loaded by checking for the presence of /dev/nvme-fabrics.

--- a/usr/lib/systemd/system/stas-config.in.target
+++ b/usr/lib/systemd/system/stas-config.in.target
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, Dell Inc. or its subsidiaries.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See the LICENSE file for details.
+#
+# This file is part of NVMe STorage Appliance Services (nvme-stas).
+#
+[Unit]
+Description=Configuration generator for @STACD_PROCNAME@.service and @STAFD_PROCNAME@.service
+Documentation=man:stas-config.target(8)
+Wants=stas-config@hostnqn.service
+Wants=stas-config@hostid.service
+PartOf=@STACD_PROCNAME@.service
+PartOf=@STAFD_PROCNAME@.service

--- a/usr/lib/systemd/system/stas-config@.service
+++ b/usr/lib/systemd/system/stas-config@.service
@@ -1,0 +1,17 @@
+# Copyright (c) 2022, Dell Inc. or its subsidiaries.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See the LICENSE file for details.
+#
+# This file is part of NVMe STorage Appliance Services (nvme-stas).
+#
+[Unit]
+Description=nvme-stas /etc/nvme/%i auto-generation
+Documentation=man:stas-config@.service(8)
+ConditionFileNotEmpty=|!/etc/nvme/%i
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/stasadm %i -f /etc/nvme/%i
+
+[Install]
+WantedBy=stas-config.target


### PR DESCRIPTION
This is a request from Red Hat for the case where nvme-stas is
copy-installed (e.g. pre-built rootfs image). In this case, nvme-
stas is not installed as a package. This means that the post-
install script doesn't get to run. The package post-install script
is where nvme-stas usually gets configured (i.e. /etc/nvme/hostnqn
and /etc/nvme/hostid get generated).

This patch allows generating /etc/nvme/hostnqn and /etc/nvme/hostid
at run time before stafd or stacd are started by systemd.

fixes issue: https://github.com/linux-nvme/nvme-stas/issues/130

Signed-off-by: Martin Belanger <martin.belanger@dell.com>