### PR TITLE
conf: fix location of sys.conf

### DIFF
--- a/stacd.py
+++ b/stacd.py
@@ -104,7 +104,6 @@ import systemd.daemon
 import dasbus.error
 import dasbus.client.observer
 import dasbus.client.proxy
-from libnvme import nvme
 from gi.repository import GLib
 from staslib import conf, log, gutil, trid, udev, ctrl, service  # pylint: disable=ungrouped-imports
 
@@ -113,8 +112,6 @@ SERVICE_CONF = conf.SvcConf()
 SERVICE_CONF.conf_file = ARGS.conf_file
 stas.trace_control(ARGS.tron or SERVICE_CONF.tron)
 
-SYSCONF = conf.SysConf()
-NVME_HOST = nvme.host(stas.NVME_ROOT, SYSCONF.hostnqn, SYSCONF.hostid, SYSCONF.hostsymname)  # Singleton
 UDEV_RULE_SUPPRESS = pathlib.Path('/run/udev/rules.d', '70-nvmf-autoconnect.rules')
 
 
@@ -141,7 +138,7 @@ class Ioc(ctrl.Controller):
     '''@brief This object establishes a connection to one I/O Controller.'''
 
     def __init__(self, tid: trid.TID):
-        super().__init__(stas.NVME_ROOT, NVME_HOST, tid)
+        super().__init__(stas.NVME_ROOT, stas.NVME_HOST, tid)
 
     def _on_udev_remove(self, udev_obj):
         '''Called when the associated nvme device (/dev/nvmeX) is removed

--- a/stafd.py
+++ b/stafd.py
@@ -133,9 +133,6 @@ SERVICE_CONF = conf.SvcConf()
 SERVICE_CONF.conf_file = ARGS.conf_file
 stas.trace_control(ARGS.tron or SERVICE_CONF.tron)
 
-SYSCONF = conf.SysConf()
-NVME_HOST = nvme.host(stas.NVME_ROOT, SYSCONF.hostnqn, SYSCONF.hostid, SYSCONF.hostsymname)  # Singleton
-
 DLP_CHANGED = (
     (nvme.NVME_LOG_LID_DISCOVER << 16) | (nvme.NVME_AER_NOTICE_DISC_CHANGED << 8) | nvme.NVME_AER_NOTICE
 )  # 0x70f002
@@ -153,7 +150,7 @@ class Dc(ctrl.Controller):
     REGISTRATION_RETRY_RERIOD_SEC = 10
 
     def __init__(self, tid: trid.TID, log_pages=None):
-        super().__init__(stas.NVME_ROOT, NVME_HOST, tid, discovery_ctrl=True)
+        super().__init__(stas.NVME_ROOT, stas.NVME_HOST, tid, discovery_ctrl=True)
         self._register_op = None
         self._get_log_op = None
         self._log_pages = log_pages if log_pages else list()  # Log pages cache

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -234,7 +234,7 @@ class SvcConf(metaclass=singleton.Singleton):
 class SysConf(metaclass=singleton.Singleton):
     '''Read and cache the host configuration file.'''
 
-    def __init__(self, conf_file='/dev/null'):
+    def __init__(self, conf_file=defs.SYS_CONF_FILE):
         self._conf_file = conf_file
         self.reload()
 
@@ -349,7 +349,7 @@ class SysConf(metaclass=singleton.Singleton):
 
 
 # ******************************************************************************
-class NvmeOptions(metaclass=singleton.Singleton):  # Singleton
+class NvmeOptions(metaclass=singleton.Singleton):
     '''Object used to read and cache contents of file /dev/nvme-fabrics.
     Note that this file was not readable prior to Linux 5.16.
     '''

--- a/staslib/defs.py
+++ b/staslib/defs.py
@@ -41,3 +41,4 @@ KERNEL_TP8013_MIN_VERSION = KernelVersion('@KERNEL_TP8013_MIN_VERSION@')
 WELL_KNOWN_DISC_NQN = 'nqn.2014-08.org.nvmexpress.discovery'
 
 PROG_NAME = os.path.basename(sys.argv[0])
+SYS_CONF_FILE = '/etc/stas/sys.conf'

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -17,7 +17,9 @@ from libnvme import nvme
 from staslib import conf, defs, trid
 
 
+SYSCONF = conf.SysConf()  # Singleton
 NVME_ROOT = nvme.root()  # Singleton
+NVME_HOST = nvme.host(NVME_ROOT, SYSCONF.hostnqn, SYSCONF.hostid, SYSCONF.hostsymname)  # Singleton
 TRON = False  # Singleton
 
 # ******************************************************************************


### PR DESCRIPTION
In the recent reshuffling of the code to break stas.py into smaller
modules, the location of the sys.conf file (/etc/stas/sys.conf) got
lost.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>