### PR TITLE
test: Fix problem between fakefs and when configuration gets loaded

### DIFF
--- a/stacd.py
+++ b/stacd.py
@@ -138,7 +138,7 @@ class Ioc(ctrl.Controller):
     '''@brief This object establishes a connection to one I/O Controller.'''
 
     def __init__(self, tid: trid.TID):
-        super().__init__(stas.NVME_ROOT, stas.NVME_HOST, tid)
+        super().__init__(stas.Nvme().root, stas.Nvme().host, tid)
 
     def _on_udev_remove(self, udev_obj):
         '''Called when the associated nvme device (/dev/nvmeX) is removed

--- a/stafd.py
+++ b/stafd.py
@@ -150,7 +150,7 @@ class Dc(ctrl.Controller):
     REGISTRATION_RETRY_RERIOD_SEC = 10
 
     def __init__(self, tid: trid.TID, log_pages=None):
-        super().__init__(stas.NVME_ROOT, stas.NVME_HOST, tid, discovery_ctrl=True)
+        super().__init__(stas.Nvme().root, stas.Nvme().host, tid, discovery_ctrl=True)
         self._register_op = None
         self._get_log_op = None
         self._log_pages = log_pages if log_pages else list()  # Log pages cache

--- a/test/test-log.py
+++ b/test/test-log.py
@@ -31,7 +31,7 @@ class StaslibLogTest(TestCase):
 #        pass
 
     def test_log_with_syslog_handler(self):
-        '''Check that we can set the handler to SysLogHandler'''
+        '''Check that we can set the handler to logging.handlers.SysLogHandler'''
         if JOURNAL_MODULE is not None:
             # We need to mask the real journal module by creating
             # a fake journal module with invalid contents
@@ -43,7 +43,7 @@ class StaslibLogTest(TestCase):
 
 
     def test_log_with_systemd_journal(self):
-        '''Check that we can set the handler to journal (needs python-systemd to be installed)'''
+        '''Check that we can set the handler to systemd.journal.JournalHandler (needs python-systemd to be installed)'''
         if JOURNAL_MODULE is not None:
             log.init(syslog=False)
             self.assertEqual(log.level(), 'DEBUG')
@@ -51,7 +51,7 @@ class StaslibLogTest(TestCase):
 
 
     def test_log_with_stdout(self):
-        '''Check that we can set the handler to SysLogHandler'''
+        '''Check that we can set the handler to logging.StreamHandler (i.e. stdout)'''
         log.init(syslog=True)
         self.assertEqual(log.level(), 'INFO')
         logging.shutdown()


### PR DESCRIPTION
When running tests, we sometimes use fakefs to fake configuration
files such as /etc/nvme/hostnqn. It's important that the configuration
singletons such as conf.SysConf() do not get created before the fakefs
has been put in place otherwise the configuration will be wrong.

This was happening because "import stas" was actually initializing
the configuration before we had time to configure the fake fs. The
solution is to never implicitly intantiate singletons (such as
conf.SysConf()) during an "import", but rather explicitly instantiate
with a function call.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>