### PR TITLE
staslib: Fix broken singleton pattern

### DIFF
--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -90,8 +90,7 @@ class SvcConf(metaclass=singleton.Singleton):
     def conf_file(self):  # pylint: disable=missing-function-docstring
         return self._conf_file
 
-    @conf_file.setter
-    def conf_file(self, fname):  # pylint: disable=missing-function-docstring
+    def set_conf_file(self, fname):  # pylint: disable=missing-function-docstring
         self._conf_file = fname
         self.reload()
 
@@ -246,8 +245,7 @@ class SysConf(metaclass=singleton.Singleton):
     def conf_file(self):  # pylint: disable=missing-function-docstring
         return self._conf_file
 
-    @conf_file.setter
-    def conf_file(self, fname):  # pylint: disable=missing-function-docstring
+    def set_conf_file(self, fname):  # pylint: disable=missing-function-docstring
         self._conf_file = fname
         self.reload()
 
@@ -376,7 +374,7 @@ class NvmeOptions(metaclass=singleton.Singleton):
                     options = [option.split('=')[0].strip() for option in f.readline().rstrip('\n').split(',')]
             except PermissionError:  # Must be root to read this file
                 raise
-            except OSError:
+            except (OSError, FileNotFoundError):
                 logging.warning('Cannot determine which NVMe options the kernel supports')
             else:
                 for option, supported in self._supported_options.items():

--- a/staslib/log.py
+++ b/staslib/log.py
@@ -45,5 +45,11 @@ def init(syslog: bool):
 
 def level() -> str:
     '''@brief return current log level'''
-    log = logging.getLogger()
-    return str(logging.getLevelName(log.getEffectiveLevel()))
+    logger = logging.getLogger()
+    return str(logging.getLevelName(logger.getEffectiveLevel()))
+
+
+def set_level_from_tron(tron):
+    '''Set log level based on TRON'''
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG if tron else logging.INFO)

--- a/staslib/singleton.py
+++ b/staslib/singleton.py
@@ -8,13 +8,11 @@
 #
 '''Implementation of a singleton pattern'''
 
-from weakref import WeakValueDictionary
-
 
 class Singleton(type):
     '''metaclass implementation of a singleton pattern'''
 
-    _instances = WeakValueDictionary()
+    _instances = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -13,27 +13,7 @@ import sys
 import ipaddress
 import logging
 
-from libnvme import nvme
-from staslib import conf, defs, singleton, trid
-
-
-TRON = False  # Singleton
-
-
-class Nvme(metaclass=singleton.Singleton):  # pylint: disable=too-few-public-methods
-    '''Singleton object to keep libnvme's root and host objects.
-    The root and host objects cannot be created too early as
-    they depend on configuration files being present. So we
-    can't create them as singleton during module import, but
-    instead they need to be created once stafd/stacd have started.
-    By using this class we ensure that things happen in the right
-    sequence.
-    '''
-
-    def __init__(self):
-        sysconf = conf.SysConf()
-        self.root = nvme.root()
-        self.host = nvme.host(self.root, sysconf.hostnqn, sysconf.hostid, sysconf.hostsymname)
+from staslib import conf, defs, trid
 
 
 # ******************************************************************************
@@ -56,18 +36,6 @@ def check_if_allowed_to_continue():
     if not os.path.exists('/dev/nvme-fabrics'):
         # There's no point going any further if the kernel module hasn't been loaded
         sys.exit('Fatal error: missing nvme-tcp kernel module')
-
-
-# ******************************************************************************
-def trace_control(tron: bool):
-    '''@brief Allows changing debug level in real time. Setting tron to True
-    enables full tracing.
-    '''
-    global TRON  # pylint: disable=global-statement
-    TRON = tron
-    log = logging.getLogger()
-    log.setLevel(logging.DEBUG if TRON else logging.INFO)
-    Nvme().root.log_level("debug" if TRON else "err")
 
 
 # ******************************************************************************

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -33,7 +33,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
     def test_config(self):
         '''Check we can read the temporary configuration file'''
         service_conf = conf.SvcConf()
-        service_conf.conf_file = StasProcessConfUnitTest.FNAME
+        service_conf.set_conf_file(StasProcessConfUnitTest.FNAME)
         self.assertEqual(service_conf.conf_file, StasProcessConfUnitTest.FNAME)
         self.assertTrue(service_conf.tron)
         self.assertFalse(service_conf.hdr_digest)
@@ -111,7 +111,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def test_config_1(self):
         '''Check we can read the temporary configuration file'''
         system_conf = conf.SysConf()
-        system_conf.conf_file = StasSysConfUnitTest.FNAME_1
+        system_conf.set_conf_file(StasSysConfUnitTest.FNAME_1)
         self.assertEqual(system_conf.conf_file, StasSysConfUnitTest.FNAME_1)
         self.assertEqual(system_conf.hostnqn, StasSysConfUnitTest.NQN)
         self.assertEqual(system_conf.hostid, StasSysConfUnitTest.ID)
@@ -128,7 +128,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def test_config_2(self):
         '''Check we can read from /dev/null or missing 'id' definition'''
         system_conf = conf.SysConf()
-        system_conf.conf_file = StasSysConfUnitTest.FNAME_2
+        system_conf.set_conf_file(StasSysConfUnitTest.FNAME_2)
         self.assertEqual(system_conf.conf_file, StasSysConfUnitTest.FNAME_2)
         self.assertIsNone(system_conf.hostnqn)
         self.assertIsNone(system_conf.hostsymname)
@@ -136,7 +136,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def test_config_3(self):
         '''Check we can read an invalid NQN string'''
         system_conf = conf.SysConf()
-        system_conf.conf_file = StasSysConfUnitTest.FNAME_3
+        system_conf.set_conf_file(StasSysConfUnitTest.FNAME_3)
         self.assertEqual(system_conf.conf_file, StasSysConfUnitTest.FNAME_3)
         self.assertRaises(SystemExit, lambda: system_conf.hostnqn)
         self.assertEqual(system_conf.hostid, StasSysConfUnitTest.ID)
@@ -145,7 +145,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def test_config_4(self):
         '''Check we can read the temporary configuration file'''
         system_conf = conf.SysConf()
-        system_conf.conf_file = StasSysConfUnitTest.FNAME_4
+        system_conf.set_conf_file(StasSysConfUnitTest.FNAME_4)
         self.assertEqual(system_conf.conf_file, StasSysConfUnitTest.FNAME_4)
         self.assertRaises(SystemExit, lambda: system_conf.hostnqn)
         self.assertRaises(SystemExit, lambda: system_conf.hostid)
@@ -154,7 +154,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def test_config_missing_file(self):
         '''Check what happens when conf file is missing'''
         system_conf = conf.SysConf()
-        system_conf.conf_file = '/just/some/ramdom/file/name'
+        system_conf.set_conf_file('/just/some/ramdom/file/name')
         self.assertIsNone(system_conf.hostsymname)
 
 

--- a/test/test-nvme_options.py
+++ b/test/test-nvme_options.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import unittest
-from staslib import conf
+from staslib import conf, log
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 
@@ -11,20 +11,13 @@ class Test(TestCase):
 
     def setUp(self):
         self.setUpPyfakefs()
+        log.init(syslog=False)
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.INFO)
 
     def tearDown(self):
         # No longer need self.tearDownPyfakefs()
         pass
-
-    def test_fabrics_doesnt_exist(self):
-        self.assertFalse(os.path.exists("/dev/nvme-fabrics"))
-        with self.assertLogs(logger=logging.getLogger()) as captured:
-            nvme_options = conf.NvmeOptions()
-            self.assertIsInstance(nvme_options.discovery_supp, bool)
-            self.assertIsInstance(nvme_options.host_iface_supp, bool)
-        self.assertEqual(len(captured.records), 1)
-        self.assertEqual(captured.records[0].getMessage(), "Cannot determine which NVMe options the kernel supports")
-        del nvme_options
 
     def test_fabrics_empty_file(self):
         self.assertFalse(os.path.exists("/dev/nvme-fabrics"))

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -4,6 +4,13 @@ import unittest
 from staslib import service
 from pyfakefs.fake_filesystem_unittest import TestCase
 
+class Args:
+    def __init__(self):
+        self.tron = True
+        self.syslog = True
+        self.conf_file = '/dev/null'
+
+
 class Test(TestCase):
     '''Unit tests for class Service'''
 
@@ -19,7 +26,8 @@ class Test(TestCase):
         # FIXME: this is hack, fix it later
         service.Service._load_last_known_config = lambda x : dict()
         # start the test
-        srv = service.Service(reload_hdlr=lambda x : x)
+
+        srv = service.Service(Args(), reload_hdlr=lambda x : x)
         self.assertRaises(NotImplementedError, srv._keep_connections_on_exit)
         self.assertRaises(NotImplementedError, srv._dump_last_known_config, [])
         self.assertRaises(NotImplementedError, srv._on_config_ctrls)


### PR DESCRIPTION
A recently introduced singleton pattern was using a weak reference
to keep track on object instances when it should have used a strong
reference. That was causing all kinds of crashes because singleton
object would suddenly be deleted w/o warning.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>