### PR TITLE
udev: fix I/O controller scan & detect algorithm

### DIFF
--- a/staslib/udev.py
+++ b/staslib/udev.py
@@ -145,10 +145,6 @@ class Udev:
         if len(list(device.children)) != 0:
             return True
 
-        subsysnqn = device.attributes.get('subsysnqn')
-        if subsysnqn is not None and subsysnqn.decode() != defs.WELL_KNOWN_DISC_NQN:
-            return True
-
         return False
 
     def find_nvme_dc_device(self, tid):


### PR DESCRIPTION
Due to the recent changes to allow connecting to fibre channel
devices, an error was introduced in the I/O controller scanning
algorithm

Signed-off-by: Martin Belanger <martin.belanger@dell.com>