### PR TITLE
stacd: fix I/O controller connection audits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # STorage Appliance Services (STAS)
 
+## Changes with release 1.1.6
+
+- Fix issues with I/O controller connection audits
+  - Eliminate pcie devices from list of I/O controller connections to audit
+  - Add soaking timer to workaround race condition between kernel and user-space applications on "add" uevents. When the kernel adds a new nvme device (e.g. `/dev/nvme7`) and sends a "add" uevent to notify user-space applications, the attributes associated with that device (e.g. `/sys/class/nvme/nvme7/cntrltype`) may not be fully initialized which can lead `stacd` to dismiss a device that should get audited. 
+
 ## Changes with release 1.1.5
 
 - Fix issues introduced in 1.1.3 when enabling Fibre Channel (FC) support. 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@ copyright = 'Copyright (c) 2022, Dell Inc. or its subsidiaries.  All rights rese
 author = 'Martin Belanger <martin.belanger@dell.com>'
 master_doc = 'index'
 
-release = '1.1.5'
+release = '1.1.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 project(
     'nvme-stas',
     meson_version: '>= 0.53.0',
-    version: '1.1.5',
+    version: '1.1.6',
     license: 'Apache-2.0',
     default_options: [
         'buildtype=release',

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -48,8 +48,7 @@ class Controller:  # pylint: disable=too-many-instance-attributes
             self._try_to_connect_deferred.cancel()
         self._try_to_connect_deferred = None
 
-        device = self.device
-        if device:
+        if self._udev:
             self._udev.unregister_for_device_events(self._on_udev_notification)
 
         if self._retry_connect_tmr is not None:

--- a/staslib/udev.py
+++ b/staslib/udev.py
@@ -189,6 +189,9 @@ class Udev:
         '''
         tids = []
         for device in self._context.list_devices(subsystem='nvme'):
+            if device.properties.get('NVME_TRTYPE', '') not in ('tcp', 'rdma', 'fc'):
+                continue
+
             if not self.is_ioc_device(device):
                 continue
 


### PR DESCRIPTION
1. Eliminate pcie devices from list of I/O controllers to audit
2. Add soaking timer to 'add events' to solve race condition with kernel

Signed-off-by: Martin Belanger <martin.belanger@dell.com>