### PR TITLE
build: increase libnvme subproject revision number

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 008a2dacdc0d29f57ec7cfd5bd6e89bf4d531081
+revision = 47e3562a7d9b4bb871f374058c52c654fb4735e9
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
libnvme 1.1 was just released. 

This pull request changes subprojects/libnvme.wrap to pull libnvme 1.1 instead of 1.0.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>