### PR TITLE
stacd: fix bug disconnect-trtypes=rdma+fc

### DIFF
--- a/doc/man/stacd.conf.xml
+++ b/doc/man/stacd.conf.xml
@@ -229,7 +229,7 @@
         <refsect2>
             <title>[I/O controller disconnect policy] section</title>
             <para>
-                Connectivity between hosts and subssystems in a fabric is
+                Connectivity between hosts and subsystems in a fabric is
                 controlled by Fabric Zoning. Entities that share a common
                 zone (i.e., are zoned together) are allowed to discover each
                 other and establish connections between them. Fabric Zoning is


### PR DESCRIPTION
When disconnect-scope=all-connections-matching-disconnect-trtypes
and disconnect-trtypes=rdma+fc, stacd removes tcp connections when
it shouldn't.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>