### PR TITLE
config: Add backward compatibility support

### DIFF
--- a/doc/man/stacd.conf.xml
+++ b/doc/man/stacd.conf.xml
@@ -216,10 +216,10 @@
                         </para>
 
                         <para>
-                            Defaults to <parameter>disabled</parameter>, which means
-                            that <code>udevd</code> will not react to AENs. This 
-                            prevents the race condition from happening by default 
-                            and error messages will not be printed to the syslog.
+                            Defaults to <parameter>enabled</parameter>, which means
+                            that <code>udevd</code> will react to AENs and there
+                            may be race conditions between <code>nvme-cli</code>
+                            and <code>nvme-stas</code>.
                         </para>
                     </listitem>
                 </varlistentry>

--- a/etc/stas/stacd.conf
+++ b/etc/stas/stacd.conf
@@ -68,7 +68,7 @@
 #            Type:    String
 #            Range:   [disabled, enabled]
 #            Default: enabled
-#udev-rule=disabled
+#udev-rule=enabled
 
 # ==============================================================================
 [I/O controller connection management]

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -73,7 +73,7 @@ class SvcConf(metaclass=singleton.Singleton):
             ('Global', 'kato'): None,
             ('Global', 'ignore-iface'): 'false',
             ('Global', 'ip-family'): 'ipv4+ipv6',
-            ('Global', 'udev-rule'): 'disabled',
+            ('Global', 'udev-rule'): 'enabled',
             ('Service Discovery', 'zeroconf'): 'enabled',
             ('Controllers', 'controller'): list(),
             ('Controllers', 'exclude'): list(),
@@ -243,6 +243,11 @@ class SvcConf(metaclass=singleton.Singleton):
         }
         '''
         controller_list = self.__get_value('Controllers', 'exclude')
+
+        # 2022-09-20: Look for "blacklist". This is for backwards compatibility
+        # with releases 1.0 to 1.1.6. This is to be phased out (i.e. remove by 2024)
+        controller_list += self.__get_value('Controllers', 'blacklist')
+
         excluded = [parse_controller(controller) for controller in controller_list]
         for controller in excluded:
             controller.pop('host-traddr', None)  # remove host-traddr

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -44,7 +44,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
         self.assertFalse(service_conf.hdr_digest)
         self.assertFalse(service_conf.data_digest)
         self.assertTrue(service_conf.persistent_connections)
-        self.assertFalse(service_conf.udev_rule_enabled)
+        self.assertTrue(service_conf.udev_rule_enabled)
         self.assertEqual(service_conf.disconnect_scope, 'only-stas-connections')
         self.assertEqual(service_conf.disconnect_trtypes, ['tcp'])
         self.assertFalse(service_conf.ignore_iface)


### PR DESCRIPTION
1. Continue supporting "blacklist" even though it was replaced by "exclude".
2. Set "udev-rule" (back) to "enabled" by default.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>