### PR TITLE
build: Rework mesong dependencies

### DIFF
--- a/doc/man/meson.build
+++ b/doc/man/meson.build
@@ -11,7 +11,11 @@ if want_man or want_html
     xsltproc = find_program('xsltproc')
     dbus2doc = find_program('dbus-idl-to-docbooks.py')
     docbklst = find_program('genlist-from-docbooks.py')
-    dbusgen  = find_program('gdbus-codegen')
+    dbusgen  = find_program('gdbus-codegen', required : false)
+
+    if not dbusgen.found()
+        error('gdbus-codegen missing: Install libglib2.0-dev (deb) / glib2-devel (rpm)')
+    endif
 
     #if readthedocs
     #    pandoc = find_program('pandoc')

--- a/meson.build
+++ b/meson.build
@@ -34,58 +34,41 @@ readthedocs = get_option('readthedocs')
 
 if readthedocs
     want_html = true
-    py_modules = ['lxml']
-    libnvme_dep = declare_dependency() # dummy dependency
-else
-    # Until python3-libnvme is widely available from distros, we need to manually
-    # pull libnvme source from Github and build as a subproject (see fallback below).
-    # Once python3-libnvme is available, we can remove the fallback code indicated
-    # by use_libnvme_fallback=true.
-    use_libnvme_fallback = true
-
-    # Check for libnvme availability
-    if use_libnvme_fallback
-        libnvme_dep = dependency('libnvme', fallback : ['libnvme', 'libnvme_dep'])
-    else
-        libnvme_dep = declare_dependency() # dummy dependency
-    endif
-
-    # Check that we have all the right Python3 dependencies
-    if use_libnvme_fallback
-        py_modules = ['dasbus', 'pyudev', 'systemd', 'gi']
-    else
-        py_modules = ['libnvme', 'dasbus', 'pyudev', 'systemd', 'gi']
-    endif
-
-    if want_man or want_html
-        py_modules += ['lxml']
-    endif
 endif
 
-python3 = import('python').find_installation('python3', modules:py_modules)
+buildtime_modules = []
+if want_man or want_html
+    buildtime_modules += ['lxml']
+endif
+
+python3 = import('python').find_installation('python3', modules:buildtime_modules)
 python_version = python3.language_version()
 python_version_req = '>=3.6'
 if not python_version.version_compare(python_version_req)
     error('Python @0@ required. Found @1@ instead'.format(python_version_req, python_version))
 endif
 
-#check_pymodules = get_option('check_pymodules')
-#if check_pymodules
-#    py_modules_reqd = [
-#        ['dasbus',    'Install python3-dasbus (deb/rpm) OR pip3 install dasbus'],
-#        ['pyudev',    'Install python3-pyudev (deb/rpm)'],
-#        ['systemd',   'Install python3-systemd (deb/rpm)'],
-#        ['gi',        'Install python3-gi (deb) OR python3-gobject (rpm)'],
-#    ]
-#    if want_man or want_html
-#        py_modules_reqd += [['lxml', 'Install python3-lxml (deb/rpm)']]
-#    endif
-#    foreach p : py_modules_reqd
-#        if run_command(python3, '-c', 'import @0@'.format(p[0]), check: false).returncode() != 0
-#            error('Required python3 module "@0@" not found. @1@'.format(p[0], p[1]))
-#        endif
-#    endforeach
-#endif
+# Check if the runtime Python modules are present. These are not needed
+# to build nvme-stas, but will be needed to run the tests.
+missing_modules = false
+py_modules_reqd = [
+    ['libnvme', 'Install python3-libnvme (deb/rpm)'],
+    ['dasbus',  'Install python3-dasbus (deb/rpm) OR pip3 install dasbus'],
+    ['pyudev',  'Install python3-pyudev (deb/rpm)'],
+    ['systemd', 'Install python3-systemd (deb/rpm)'],
+    ['gi',      'Install python3-gi (deb) OR python3-gobject (rpm)'],
+]
+foreach p : py_modules_reqd
+    if run_command(python3, '-c', 'import @0@'.format(p[0]), check: false).returncode() != 0
+        warning('Missing runtime module "@0@". @1@'.format(p[0], p[1]))
+        missing_modules = true
+    endif
+endforeach
+
+if missing_modules and get_option('rt_pymods_reqd')
+    error('Please install missing runtime modules')
+endif
+
 
 #===============================================================================
 conf = configuration_data()
@@ -167,12 +150,7 @@ endforeach
 
 #===========================================================================
 # Make a list of modules to lint
-if libnvme_dep.found()
-    modules_to_lint = [stafd, stafctl, stacd, stacctl, stasadm]
-else
-    warning('Install the libnvme Python package to run the tests.')
-    modules_to_lint = []
-endif
+modules_to_lint = [stafd, stafctl, stacd, stacctl, stasadm]
 
 #===========================================================================
 subdir('staslib')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 # -*- mode: meson -*-
 
-option('man',             type: 'boolean', value: false, description: 'build and install man pages')
-option('html',            type: 'boolean', value: false, description: 'build and install html pages')
-option('readthedocs',     type: 'boolean', value: false,  description: 'to be used by Read-The-Docs documentation builder')
-#option('check_pymodules', type: 'boolean', value: true,  description: 'whether to look for missing python module')
+option('man',         type: 'boolean', value: false, description: 'build and install man pages')
+option('html',        type: 'boolean', value: false, description: 'build and install html pages')
+option('readthedocs', type: 'boolean', value: false,  description: 'to be used by Read-The-Docs documentation builder')
+option('rt_pymods_reqd', type: 'boolean', value: false,  description: 'Make sure all runti python modules are installed')

--- a/nvme-stas.spec.in
+++ b/nvme-stas.spec.in
@@ -12,24 +12,24 @@ BuildRequires: glib2-devel
 #BuildRequires: libnvme-devel
 BuildRequires: libxslt
 BuildRequires: docbook-style-xsl
-BuildRequires: systemd-devel
+#BuildRequires: systemd-devel
 BuildRequires: systemd-rpm-macros
 
 BuildRequires: python3
 #BuildRequires: python3-devel
-BuildRequires: python3-pyflakes
-BuildRequires: python3-pylint
-BuildRequires: pylint
+#BuildRequires: python3-pyflakes
+#BuildRequires: python3-pylint
+#BuildRequires: pylint
 
 #BuildRequires: python3-libnvme
-BuildRequires: python3-dasbus
-BuildRequires: python3-pyudev
-BuildRequires: python3-systemd
-BuildRequires: python3-gobject-devel
+#BuildRequires: python3-dasbus
+#BuildRequires: python3-pyudev
+#BuildRequires: python3-systemd
+#BuildRequires: python3-gobject-devel
 BuildRequires: python3-lxml
 
 Requires:      avahi
-#Requires:      python3-libnvme
+Requires:      python3-libnvme
 Requires:      python3-dasbus
 Requires:      python3-pyudev
 Requires:      python3-systemd

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -25,7 +25,7 @@ def get_eflags(dlpe):
 
 def get_ncc(eflags: int):
     '''@brief Return True if Not Connected to CDC bit is asserted, False otherwise'''
-    return 0 != (eflags & nvme.NVMF_DISC_EFLAGS_NCC)
+    return eflags & nvme.NVMF_DISC_EFLAGS_NCC != 0
 
 
 def dlp_supp_opts_as_string(dlp_supp_opts):

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,6 +24,8 @@ test_env.prepend('PYTHONPATH', PYTHONPATH)
 
 # pylint and pyflakes
 if modules_to_lint.length() != 0
+    #libnvme_dep = dependency('python3-libnvme', fallback : ['libnvme', 'libnvme_dep'], version : '>= 1.2')
+    libnvme_dep = dependency('python3-libnvme', fallback : ['libnvme', 'libnvme_dep'])
     pylint = find_program('pylint', required: false)
     pyflakes = find_program('pyflakes3', required: false)
     if not pyflakes.found()
@@ -63,20 +65,20 @@ foreach thing: things_to_test
     msg = thing[0]
 
     # Check whether all dependencies can be found
-    deps_found = true
+    missing_deps = []
     deps = thing[2]
     foreach dep : deps
         if run_command(python3, '-c', 'import @0@'.format(dep), check: false).returncode() != 0
-            deps_found = false
-            warning('"@0@" requires python module "@1@"'.format(msg, dep))
-            break
+            missing_deps += [dep]
         endif
     endforeach
 
-    # Run the test if all dependencies are available
-    if deps_found
+    if missing_deps.length() == 0
+        # Run the test if all dependencies are available
         script = join_paths(meson.current_source_dir(), thing[1])
         test(msg, python3, args: script, env: test_env)
+    else
+        warning('"@0@" requires python module "@1@"'.format(msg, missing_deps))
     endif
 endforeach
 


### PR DESCRIPTION
Meson only cares about build-time dependencies. Made the runtime dependencies optional.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>