### PR TITLE
staslib: Trim white spaces from transport identifiers

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -220,7 +220,7 @@ ip-family=ipv4
 kato=10
 
 [Controllers]
-controller=transport=tcp;traddr=localhost
+controller = transport = tcp ; traddr = localhost ; ; ;
 controller=transport=tcp;traddr=1.1.1.1
 controller=transport=tcp;traddr=2.2.2.2
 controller=transport=tcp;traddr=555.555.555.555

--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -408,11 +408,11 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         service = (interface, protocol, name, stype, domain)
         if service in self._services:
             self._services[service]['data'] = {
-                'transport':  txt.get('p', 'tcp'),
-                'traddr':     address,
-                'trsvcid':    str(port),
-                'host-iface': socket.if_indextoname(interface),
-                'subsysnqn':  txt.get('NQN', defs.WELL_KNOWN_DISC_NQN)
+                'transport':  txt.get('p', 'tcp').strip(),
+                'traddr':     address.strip(),
+                'trsvcid':    str(port).strip(),
+                'host-iface': socket.if_indextoname(interface).strip(),
+                'subsysnqn':  txt.get('NQN', defs.WELL_KNOWN_DISC_NQN).strip()
                               if conf.NvmeOptions().discovery_supp
                               else defs.WELL_KNOWN_DISC_NQN,
             }

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -32,7 +32,7 @@ def parse_controller(controller):
         if token:
             try:
                 option, val = __OPTION_RE.split(token)
-                options[option] = val
+                options[option.strip()] = val.strip()
             except ValueError:
                 pass
 

--- a/staslib/trid.py
+++ b/staslib/trid.py
@@ -31,17 +31,17 @@ class TID:  # pylint: disable=too-many-instance-attributes
             'host-iface':  str, # [optional]
         }
         '''
-        self._transport = cid.get('transport', '')
-        self._traddr    = cid.get('traddr', '')
+        self._transport = cid.get('transport', '').strip()
+        self._traddr    = cid.get('traddr', '').strip()
         self._trsvcid   = ''
         if self._transport in ('tcp', 'rdma'):
             trsvcid = cid.get('trsvcid', None)
             self._trsvcid = (
-                trsvcid if trsvcid else (TID.RDMA_IP_PORT if self._transport == 'rdma' else TID.DISC_IP_PORT)
+                trsvcid.strip() if trsvcid else (TID.RDMA_IP_PORT if self._transport == 'rdma' else TID.DISC_IP_PORT)
             )
-        self._host_traddr = cid.get('host-traddr', '')
-        self._host_iface  = '' if conf.SvcConf().ignore_iface else cid.get('host-iface', '')
-        self._subsysnqn   = cid.get('subsysnqn', '')
+        self._host_traddr = cid.get('host-traddr', '').strip()
+        self._host_iface  = '' if conf.SvcConf().ignore_iface else cid.get('host-iface', '').strip()
+        self._subsysnqn   = cid.get('subsysnqn', '').strip()
         self._shortkey    = (self._transport, self._traddr, self._trsvcid, self._subsysnqn, self._host_traddr)
         self._key         = (self._transport, self._traddr, self._trsvcid, self._subsysnqn, self._host_traddr, self._host_iface)
         self._hash        = int.from_bytes(hashlib.md5(''.join(self._key).encode('utf-8')).digest(), 'big')  # We need a consistent hash between restarts

--- a/test/test-transport_id.py
+++ b/test/test-transport_id.py
@@ -83,5 +83,27 @@ class Test(unittest.TestCase):
         self.assertNotEqual(self.tid, 'hello')
 
 
+    def test_white_spaces(self):
+        '''Check that white spaces get stripped'''
+
+        cid = {
+            'transport': ' tcp ',
+            'traddr': ' 0.0.0.0   ',
+            'subsysnqn': ' hello ',
+            'trsvcid': ' 8009 ',
+            'host-traddr': ' 1.1.1.1 ',
+            'host-iface': ' eth1234 ',
+        }
+
+        tid = trid.TID(cid)
+
+        self.assertEqual(tid.transport, 'tcp')
+        self.assertEqual(tid.traddr, '0.0.0.0')
+        self.assertEqual(tid.subsysnqn, 'hello')
+        self.assertEqual(tid.trsvcid, '8009')
+        self.assertEqual(tid.host_traddr, '1.1.1.1')
+        self.assertEqual(tid.host_iface, 'eth1234')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixe https://github.com/linux-nvme/nvme-stas/issues/271

Signed-off-by: Martin Belanger <martin.belanger@dell.com>