### PR TITLE
test: Always run tests using libnvme subproject

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -6,7 +6,9 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-libnvme_dep = dependency('python3-libnvme', fallback: ['libnvme', 'libnvme_dep'], version : '>= 1.2', required: false)  # Only required to run the tests
+
+libnvme_proj = subproject('libnvme')
+libnvme_dep = libnvme_proj.get_variable('libnvme_dep')
 
 if libnvme_dep.found()
     test_env = environment({'MALLOC_PERTURB_': '0'})


### PR DESCRIPTION
In other words, don't use already installed libnvme to run the tests. This could be an older incompatible version that would cause the tests to fail.

Fixes https://github.com/linux-nvme/nvme-stas/issues/270

Signed-off-by: Martin Belanger <martin.belanger@dell.com>