### PR TITLE
staslib: Trim whitespaces at the source

### DIFF
--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -587,9 +587,9 @@ class Dc(Controller):
             referrals_before = self.referrals()
             self._log_pages = (
                 [
-                    {k: str(v) for k, v in dictionary.items()}
+                    {k.strip(): str(v).strip() for k, v in dictionary.items()}
                     for dictionary in data
-                    if dictionary.get('traddr') not in ('0.0.0.0', '::', '')
+                    if dictionary.get('traddr','').strip() not in ('0.0.0.0', '::', '')
                 ]
                 if data
                 else list()

--- a/staslib/trid.py
+++ b/staslib/trid.py
@@ -31,17 +31,17 @@ class TID:  # pylint: disable=too-many-instance-attributes
             'host-iface':  str, # [optional]
         }
         '''
-        self._transport = cid.get('transport', '').strip()
-        self._traddr    = cid.get('traddr', '').strip()
+        self._transport = cid.get('transport', '')
+        self._traddr    = cid.get('traddr', '')
         self._trsvcid   = ''
         if self._transport in ('tcp', 'rdma'):
             trsvcid = cid.get('trsvcid', None)
             self._trsvcid = (
-                trsvcid.strip() if trsvcid else (TID.RDMA_IP_PORT if self._transport == 'rdma' else TID.DISC_IP_PORT)
+                trsvcid if trsvcid else (TID.RDMA_IP_PORT if self._transport == 'rdma' else TID.DISC_IP_PORT)
             )
-        self._host_traddr = cid.get('host-traddr', '').strip()
-        self._host_iface  = '' if conf.SvcConf().ignore_iface else cid.get('host-iface', '').strip()
-        self._subsysnqn   = cid.get('subsysnqn', '').strip()
+        self._host_traddr = cid.get('host-traddr', '')
+        self._host_iface  = '' if conf.SvcConf().ignore_iface else cid.get('host-iface', '')
+        self._subsysnqn   = cid.get('subsysnqn', '')
         self._shortkey    = (self._transport, self._traddr, self._trsvcid, self._subsysnqn, self._host_traddr)
         self._key         = (self._transport, self._traddr, self._trsvcid, self._subsysnqn, self._host_traddr, self._host_iface)
         self._hash        = int.from_bytes(hashlib.md5(''.join(self._key).encode('utf-8')).digest(), 'big')  # We need a consistent hash between restarts

--- a/test/test-transport_id.py
+++ b/test/test-transport_id.py
@@ -82,28 +82,5 @@ class Test(unittest.TestCase):
         self.assertNotEqual(self.tid, self.other_tid)
         self.assertNotEqual(self.tid, 'hello')
 
-
-    def test_white_spaces(self):
-        '''Check that white spaces get stripped'''
-
-        cid = {
-            'transport': ' tcp ',
-            'traddr': ' 0.0.0.0   ',
-            'subsysnqn': ' hello ',
-            'trsvcid': ' 8009 ',
-            'host-traddr': ' 1.1.1.1 ',
-            'host-iface': ' eth1234 ',
-        }
-
-        tid = trid.TID(cid)
-
-        self.assertEqual(tid.transport, 'tcp')
-        self.assertEqual(tid.traddr, '0.0.0.0')
-        self.assertEqual(tid.subsysnqn, 'hello')
-        self.assertEqual(tid.trsvcid, '8009')
-        self.assertEqual(tid.host_traddr, '1.1.1.1')
-        self.assertEqual(tid.host_iface, 'eth1234')
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The previous fix was trimming whitespaces too late leaving some data structures containing untrimmed strings. This moves the trimming at the point where DLPEs are received from libnvme and trims them right there and then.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>