### PR TITLE
staslib: Trim white spaces from DLPEs and manual configuration.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # STorage Appliance Services (STAS)
 
+## Changes with release 1.1.7
+
+- Trim white spaces from Discovery Log Pages Entries (DLPE) and Configuration parameters.
+  - Parameters such as traddr, trsvcid, etc. may be padded with white spaces. These white spaces need to be trimmed off before sending to the kernel driver.
+
 ## Changes with release 1.1.6
 
 - Fix issues with I/O controller connection audits

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@ copyright = 'Copyright (c) 2022, Dell Inc. or its subsidiaries.  All rights rese
 author = 'Martin Belanger <martin.belanger@dell.com>'
 master_doc = 'index'
 
-release = '1.1.6'
+release = '1.1.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 project(
     'nvme-stas',
     meson_version: '>= 0.53.0',
-    version: '1.1.6',
+    version: '1.1.7',
     license: 'Apache-2.0',
     default_options: [
         'buildtype=release',

--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -408,11 +408,11 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         service = (interface, protocol, name, stype, domain)
         if service in self._services:
             self._services[service]['data'] = {
-                'transport':  txt.get('p', 'tcp'),
-                'traddr':     address,
-                'trsvcid':    str(port),
-                'host-iface': socket.if_indextoname(interface),
-                'subsysnqn':  txt.get('NQN', defs.WELL_KNOWN_DISC_NQN)
+                'transport':  txt.get('p', 'tcp').strip(),
+                'traddr':     address.strip(),
+                'trsvcid':    str(port).strip(),
+                'host-iface': socket.if_indextoname(interface).strip(),
+                'subsysnqn':  txt.get('NQN', defs.WELL_KNOWN_DISC_NQN).strip()
                               if conf.NvmeOptions().discovery_supp
                               else defs.WELL_KNOWN_DISC_NQN,
             }

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -32,7 +32,7 @@ def parse_controller(controller):
         if token:
             try:
                 option, val = __OPTION_RE.split(token)
-                options[option] = val
+                options[option.strip()] = val.strip()
             except ValueError:
                 pass
 

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -428,9 +428,9 @@ class Dc(Controller):
             referrals_before = self.referrals()
             self._log_pages = (
                 [
-                    {k: str(v) for k, v in dictionary.items()}
+                    {k.strip(): str(v).strip() for k, v in dictionary.items()}
                     for dictionary in data
-                    if dictionary.get('traddr') not in ('0.0.0.0', '::', '')
+                    if dictionary.get('traddr','').strip() not in ('0.0.0.0', '::', '')
                 ]
                 if data
                 else list()

--- a/staslib/udev.py
+++ b/staslib/udev.py
@@ -241,6 +241,6 @@ UDEV = Udev()  # Singleton
 
 def shutdown():
     '''Destroy the UDEV singleton'''
-    global UDEV  # pylint: disable=global-statement
+    global UDEV  # pylint: disable=global-statement,global-variable-not-assigned
     UDEV.release_resources()
     del UDEV


### PR DESCRIPTION
Parameters such as traddr, trsvcid, etc. may contain leading and/or trailing white spaces. These need to be trimmed.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>