### PR TITLE
stafd: Fix handling of lost zeroconf-discovered DC

### DIFF
--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -448,15 +448,17 @@ class Dc(Controller):  # pylint: disable=too-many-instance-attributes
         if self.origin == 'discovered':  # Only apply to mDNS-discovered DCs
             if not self._staf.is_avahi_reported(self.tid) and not self.connected():
                 timeout = conf.SvcConf().zeroconf_persistence_sec
-                if self._ctrl_lost_time is None and timeout >= 0:
-                    self._ctrl_lost_time = time.localtime()
-                    self._ctrl_lost_tmr.start(timeout)
-                    logging.info(
-                        '%s | %s - Controller is not responding. Will be removed by %s unless restored',
-                        self.id,
-                        self.device,
-                        time.ctime(time.mktime(self._ctrl_lost_time) + timeout),
-                    )
+                if timeout >= 0:
+                    if self._ctrl_lost_time is None:
+                        self._ctrl_lost_time = time.localtime()
+                        self._ctrl_lost_tmr.start(timeout)
+                        logging.info(
+                            '%s | %s - Controller is not responding. Will be removed by %s unless restored',
+                            self.id,
+                            self.device,
+                            time.ctime(time.mktime(self._ctrl_lost_time) + timeout),
+                        )
+
                     return
 
                 logging.info(

--- a/staslib/service.py
+++ b/staslib/service.py
@@ -529,6 +529,14 @@ class Staf(Service):
             for dlpe in controller.referrals()
         ]
 
+    def remove_controller(self, controller, success):  # pylint: disable=unused-argument
+        '''@brief remove the specified controller object from the list of controllers
+        @param controller: the controller object
+        @param success: whether the disconnect was successful'''
+        logging.debug('Staf.remove_controller()')
+        self.log_pages_changed(controller, controller.device)
+        super().remove_controller(controller, success)
+
     def _config_ctrls_finish(self, configured_ctrl_list: list):
         '''@brief Finish discovery controllers configuration after
         hostnames (if any) have been resolved.

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -117,7 +117,7 @@ def remove_excluded(controllers: list):
     '''
     excluded_ctrl_list = conf.SvcConf().get_excluded()
     if excluded_ctrl_list:
-        logging.debug('remove_excluded()                  - excluded_ctrl_list = %s', excluded_ctrl_list)
+        logging.debug('remove_excluded()                  - excluded_ctrl_list   = %s', excluded_ctrl_list)
         controllers = [
             controller for controller in controllers if not _excluded(excluded_ctrl_list, controller.as_dict())
         ]


### PR DESCRIPTION
zeroconf (mDNS) Discovery Controllers that stop responding and for which mDNS discovery has also stopped responding, need to be removed after "zeroconf-connections-persistence" seconds. Found a problem in the logic that would cause the timeout to be mishandled.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>