### PR TITLE
staslib: fix RoCE support

### DIFF
--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -408,10 +408,16 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
         service = (interface, protocol, name, stype, domain)
         if service in self._services:
             self._services[service]['data'] = {
-                'transport':  txt.get('p', 'tcp').strip(),
+                # choose transport as rdma if not tcp
+                'transport':  'tcp'
+                              if txt.get('p', 'tcp').strip() == 'tcp'
+                              else 'rdma',
                 'traddr':     address.strip(),
                 'trsvcid':    str(port).strip(),
-                'host-iface': socket.if_indextoname(interface).strip(),
+                # host-iface permitted for tcp alone and not rdma
+                'host-iface': socket.if_indextoname(interface).strip()
+                              if txt.get('p', 'tcp').strip() == 'tcp'
+                              else '',
                 'subsysnqn':  txt.get('nqn', defs.WELL_KNOWN_DISC_NQN).strip()
                               if conf.NvmeOptions().discovery_supp
                               else defs.WELL_KNOWN_DISC_NQN,

--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -407,17 +407,14 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
 
         service = (interface, protocol, name, stype, domain)
         if service in self._services:
+            transport = 'tcp' if txt.get('p', 'tcp').strip() == 'tcp' else 'rdma'
             self._services[service]['data'] = {
                 # choose transport as rdma if not tcp
-                'transport':  'tcp'
-                              if txt.get('p', 'tcp').strip() == 'tcp'
-                              else 'rdma',
+                'transport':  transport,
                 'traddr':     address.strip(),
                 'trsvcid':    str(port).strip(),
                 # host-iface permitted for tcp alone and not rdma
-                'host-iface': socket.if_indextoname(interface).strip()
-                              if txt.get('p', 'tcp').strip() == 'tcp'
-                              else '',
+                'host-iface': socket.if_indextoname(interface).strip() if transport == 'tcp' else '',
                 'subsysnqn':  txt.get('nqn', defs.WELL_KNOWN_DISC_NQN).strip()
                               if conf.NvmeOptions().discovery_supp
                               else defs.WELL_KNOWN_DISC_NQN,

--- a/staslib/avahi.py
+++ b/staslib/avahi.py
@@ -376,7 +376,7 @@ class Avahi:  # pylint: disable=too-many-instance-attributes
 
         self._change_cb()
 
-    def _service_identified(
+    def _service_identified(  # pylint: disable=too-many-locals
         self,
         _connection,
         _sender_name: str,

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -289,7 +289,7 @@ class SvcConf(metaclass=singleton.Singleton):  # pylint: disable=too-many-public
 
     def get_stypes(self):
         '''@brief Get the DNS-SD/mDNS service types.'''
-        return ['_nvme-disc._tcp'] if self.zeroconf_enabled() else list()
+        return ['_nvme-disc._tcp','_nvme-disc._udp'] if self.zeroconf_enabled() else list()
 
     def zeroconf_enabled(self):  # pylint: disable=missing-function-docstring
         return self.__get_value('Service Discovery', 'zeroconf') == 'enabled'


### PR DESCRIPTION
NVMe TP 8009 mentions using UDP for RoCE. However, nvme-stas currently registers for the TCP discovery service alone, and not UDP. So while avahi can see the RoCE service on the target, nvme-stas doesn't ask to be alerted to them. So update avahi to handle the same. Also, nvme-stas should convert p=roce in TXT to rdma when creating discovery controllers. And finally, ensure host-iface is avoided for RDMA controllers since it is not permitted in the kernel.

Signed-off-by: Martin George <marting@netapp.com>