### PR TITLE
staslib: Fix memory corruption when running multiple threads

### DIFF
--- a/.coveragerc.in
+++ b/.coveragerc.in
@@ -20,7 +20,6 @@ exclude_lines =
 
 	# Don't complain if tests don't hit defensive assertion code:
 	raise AssertionError
-	raise NotImplementedError
 	raise RuntimeError
 
 	# Don't complain if non-runnable code isn't run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,8 +23,8 @@ env:
 
 
 jobs:
-  build:
-
+  docker-publish:
+    if: ${{ !github.event.act }} # skip during local actions testing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -9,14 +9,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux:
+  docker-run:
+    if: ${{ !github.event.act }} # skip during local actions testing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: Install requirements
         # make sure nvme-cli installed (we need it for /etc/nvme/hostnqn and /etc/nvme/hostid)
-        run: sudo apt-get install -y nvme-cli
+        run: sudo apt-get install --yes --quiet nvme-cli
 
       - name: Load Kernel drivers
         run: sudo modprobe -v nvme-fabrics

--- a/.github/workflows/meson-test.yml
+++ b/.github/workflows/meson-test.yml
@@ -9,22 +9,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux:
+  meson-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get upgrade
-          sudo apt-get install -y meson docbook-xml docbook-xsl xsltproc libjson-c-dev libglib2.0-dev libgirepository1.0-dev libsystemd-dev python3-systemd python3-pyudev python3-lxml
-          python3 -m pip install --upgrade pip wheel
-          python3 -m pip install --upgrade dasbus pylint pyflakes PyGObject
-          python3 -m pip install --upgrade vermin
-          python3 -m pip install --upgrade pyfakefs
-          python3 -m pip install --upgrade importlib-resources
+      - name: "CHECKOUT: nvme-stas"
+        uses: actions/checkout@v3
 
-      - uses: BSFishy/meson-build@v1.0.3
+      - name: "INSTALL: Overall dependencies"
+        run: |
+          sudo apt-get update --yes --quiet
+          sudo apt-get upgrade --yes --quiet
+          sudo apt-get install --yes --quiet python3-pip cmake iproute2
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install --upgrade wheel meson ninja
+
+      - name: "INSTALL: nvme-stas dependencies"
+        run: |
+          sudo apt-get install --yes --quiet docbook-xml docbook-xsl xsltproc libglib2.0-dev libgirepository1.0-dev libsystemd-dev python3-systemd python3-pyudev python3-lxml
+          python3 -m pip install --upgrade dasbus pylint pyflakes PyGObject
+          python3 -m pip install --upgrade vermin pyfakefs importlib-resources
+
+      - name: "INSTALL: libnvme"
+        run: |
+          sudo apt-get install --yes --quiet swig libjson-c-dev
+          meson subprojects download
+          meson setup .build subprojects/libnvme -Dlibdbus=disabled -Dopenssl=disabled -Dbuildtype=release -Dprefix=/usr -Dpython=true
+          ninja -C .build
+          sudo meson install -C .build
+
+      - name: "CONFIG: PYTHONPATH"
+        run: |
+          echo "PYTHONPATH=.build:.build/subprojects/libnvme:/usr/lib/python3/dist-packages/" >> $GITHUB_ENV
+
+      - name: "TEST: nvme-stas"
+        uses: BSFishy/meson-build@v1.0.3
         with:
           action: test
           directory: .build
@@ -35,10 +53,10 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: Linux_Meson_Testlog
+          name: "Linux_Meson_Testlog"
           path: .build/meson-logs/*
 
-      - name: Generate coverage report
+      - name: "Generate coverage report"
         run: |
           python3 -m pip install pytest
           python3 -m pip install pytest-cov

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
 
   docker-lint:
+    if: ${{ !github.event.act }} # skip during local actions testing
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -22,33 +23,52 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: "CHECKOUT: nvme-stas"
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: "UPGRADE: existing packages"
         run: |
-          sudo apt-get update
-          sudo apt-get upgrade
-          sudo apt-get install -y meson libgirepository1.0-dev libsystemd-dev python3-systemd python3-pyudev python3-lxml
-          python3 -m pip install --upgrade pip wheel
-          python3 -m pip install --upgrade meson dasbus pylint pyflakes PyGObject
+          sudo apt-get update --yes --quiet || true
+          sudo apt-get upgrade --yes --quiet || true
 
-      - name: Install libnvme
+      - name: "INSTALL: additional packages"
         run: |
+          sudo apt-get install --yes --quiet python3-pip || true
+          sudo apt-get install --yes --quiet cmake || true
+          sudo apt-get install --yes --quiet libgirepository1.0-dev || true
+          sudo apt-get install --yes --quiet libsystemd-dev || true
+          sudo apt-get install --yes --quiet python3-systemd || true
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install --upgrade wheel
+          sudo python3 -m pip install --upgrade meson
+          sudo python3 -m pip install --upgrade ninja
+          python3 -m pip install --upgrade dasbus
+          python3 -m pip install --upgrade pylint
+          python3 -m pip install --upgrade pyflakes
+          python3 -m pip install --upgrade PyGObject
+          python3 -m pip install --upgrade lxml
+          python3 -m pip install --upgrade pyudev
+
+      - name: "BUILD: libnvme"
+        run: |
+          sudo apt-get install --yes --quiet swig libjson-c-dev || true
           meson subprojects download
-          meson setup builddir subprojects/libnvme
+          meson setup builddir subprojects/libnvme -Dlibdbus=disabled -Dopenssl=disabled -Dbuildtype=release -Dprefix=/usr -Dpython=true
           ninja -C builddir
+          sudo meson install -C builddir
 
       - name: Set PYTHONPATH
         run: |
-          echo "PYTHONPATH=builddir:/usr/lib/python3/dist-packages/" >> $GITHUB_ENV
+          echo "PYTHONPATH=builddir:builddir/subprojects/libnvme:/usr/lib/python3/dist-packages/" >> $GITHUB_ENV
 
       - name: Show test environment
         run: |
+          echo -e "Build Directory:\n$(ls -laF builddir)"
           python3 -VV
           python3 -m site
           python3 -m pylint --version

--- a/stacctl.py
+++ b/stacctl.py
@@ -34,7 +34,7 @@ def troff(args):  # pylint: disable=unused-argument
     print(f'tron = {iface.tron}')  # Read value back from stacd and print
 
 
-def _extract_cid(ctrl):  # pylint: disable=missing-function-docstring
+def _extract_cid(ctrl):
     return (
         ctrl['transport'],
         ctrl['traddr'],

--- a/stacd.py
+++ b/stacd.py
@@ -15,7 +15,8 @@ from staslib import defs
 
 
 # ******************************************************************************
-def parse_args(conf_file: str):  # pylint: disable=missing-function-docstring
+def parse_args(conf_file: str):
+    '''Parse command line options'''
     parser = ArgumentParser(description='STorage Appliance Connector (STAC). Must be root to run this program.')
     parser.add_argument(
         '-f',

--- a/stafctl.py
+++ b/stafctl.py
@@ -34,7 +34,7 @@ def troff(args):  # pylint: disable=unused-argument
     print(f'tron = {iface.tron}')  # Read value back from stafd and print
 
 
-def _extract_cid(ctrl):  # pylint: disable=missing-function-docstring
+def _extract_cid(ctrl):
     return (
         ctrl['transport'],
         ctrl['traddr'],

--- a/stafd.py
+++ b/stafd.py
@@ -15,7 +15,8 @@ from staslib import defs
 
 
 # ******************************************************************************
-def parse_args(conf_file: str):  # pylint: disable=missing-function-docstring
+def parse_args(conf_file: str):
+    '''Parse command line options'''
     parser = ArgumentParser(description='STorage Appliance Finder (STAF). Must be root to run this program.')
     parser.add_argument(
         '-f',

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -79,10 +79,12 @@ class SvcConf(metaclass=singleton.Singleton):  # pylint: disable=too-many-public
         self._config = self.read_conf_file()
 
     @property
-    def conf_file(self):  # pylint: disable=missing-function-docstring
+    def conf_file(self):
+        '''Return the configuration file name'''
         return self._conf_file
 
-    def set_conf_file(self, fname):  # pylint: disable=missing-function-docstring
+    def set_conf_file(self, fname):
+        '''Set the configuration file name and reload config'''
         self._conf_file = fname
         self.reload()
 
@@ -109,10 +111,12 @@ class SvcConf(metaclass=singleton.Singleton):  # pylint: disable=too-many-public
         ) or self.__get_bool('Global', 'persistent-connections')
 
     @property
-    def zeroconf_persistence_sec(self):  # pylint: disable=invalid-name
+    def zeroconf_persistence_sec(self):
         '''@brief return the "zeroconf-connections-persistence" config parameter, in seconds'''
-        value = self.__get_value('Discovery controller connection management', 'zeroconf-connections-persistence')
-        return timeparse.timeparse(value)
+        section = 'Discovery controller connection management'
+        option = 'zeroconf-connections-persistence'
+        value = self.__get_value(section, option)
+        return timeparse.timeparse(value) if value is not None else self._defaults.get((section, option), None)
 
     @property
     def ignore_iface(self):
@@ -286,7 +290,8 @@ class SvcConf(metaclass=singleton.Singleton):  # pylint: disable=too-many-public
         '''@brief Get the DNS-SD/mDNS service types.'''
         return ['_nvme-disc._tcp', '_nvme-disc._udp'] if self.zeroconf_enabled() else list()
 
-    def zeroconf_enabled(self):  # pylint: disable=missing-function-docstring
+    def zeroconf_enabled(self):
+        '''Return the value for "zeroconf="'''
         return self.__get_value('Service Discovery', 'zeroconf') == 'enabled'
 
     def read_conf_file(self):
@@ -405,14 +410,17 @@ class SysConf(metaclass=singleton.Singleton):
         self._config = self.read_conf_file()
 
     @property
-    def conf_file(self):  # pylint: disable=missing-function-docstring
+    def conf_file(self):
+        '''Return the configuration file name'''
         return self._conf_file
 
-    def set_conf_file(self, fname):  # pylint: disable=missing-function-docstring
+    def set_conf_file(self, fname):
+        '''Set the configuration file name and reload config'''
         self._conf_file = fname
         self.reload()
 
-    def as_dict(self):  # pylint: disable=missing-function-docstring
+    def as_dict(self):
+        '''Return configuration as a dictionary'''
         return {
             'hostnqn': self.hostnqn,
             'hostid': self.hostid,

--- a/staslib/gutil.py
+++ b/staslib/gutil.py
@@ -305,7 +305,8 @@ class AsyncTask:  # pylint: disable=too-many-instance-attributes
     def __str__(self):
         return str(self.as_dict())
 
-    def as_dict(self):  # pylint: disable=missing-function-docstring
+    def as_dict(self):
+        '''Return object members as a dictionary'''
         info = {
             'fail count': self._fail_cnt,
         }

--- a/staslib/timeparse.py
+++ b/staslib/timeparse.py
@@ -52,16 +52,13 @@ def _opt(string):
 
 
 def _optsep(string):
-    # pylint: disable=consider-using-f-string
-    return r'(?:{x}\s*(?:{SEPARATORS}\s*)?)?'.format(x=string, SEPARATORS=SEPARATORS)
+    return fr'(?:{string}\s*(?:{SEPARATORS}\s*)?)?'
 
 
 TIMEFORMATS = [
-    r'{DAYS}\s*{HOURS}\s*{MINS}\s*{SECS}'.format(  # pylint: disable=consider-using-f-string
-        DAYS=_optsep(DAYS), HOURS=_optsep(HOURS), MINS=_optsep(MINS), SECS=_opt(SECS)
-    ),
+    fr'{_optsep(DAYS)}\s*{_optsep(HOURS)}\s*{_optsep(MINS)}\s*{_opt(SECS)}',
     f'{MINCLOCK}',
-    r'{DAYS}\s*{HOURCLOCK}'.format(DAYS=_optsep(DAYS), HOURCLOCK=HOURCLOCK),  # pylint: disable=consider-using-f-string
+    fr'{_optsep(DAYS)}\s*{HOURCLOCK}',
     f'{DAYCLOCK}',
     f'{SECCLOCK}',
 ]
@@ -109,6 +106,8 @@ def timeparse(sval):
     '''
     try:
         return float(sval)
+    except TypeError:
+        pass
     except ValueError:
         match = COMPILED_SIGN.match(sval)
         sign = -1 if match.groupdict()['sign'] == '-' else 1

--- a/staslib/trid.py
+++ b/staslib/trid.py
@@ -71,7 +71,8 @@ class TID:  # pylint: disable=too-many-instance-attributes
     def subsysnqn(self):  # pylint: disable=missing-function-docstring
         return self._subsysnqn
 
-    def as_dict(self):  # pylint: disable=missing-function-docstring
+    def as_dict(self):
+        '''Return object members as a dictionary'''
         return {
             'transport': self.transport,
             'traddr': self.traddr,

--- a/test/test-avahi.py
+++ b/test/test-avahi.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python3
+import shutil
 import logging
 import unittest
 from staslib import avahi
 import dasbus.connection
 import subprocess
+
+SYSTEMCTL = shutil.which('systemctl')
 
 class Test(unittest.TestCase):
     '''Unit tests for class Avahi'''
@@ -16,7 +19,7 @@ class Test(unittest.TestCase):
 
         try:
             # Check that the Avahi daemon is running
-            subprocess.run(['systemctl', 'is-active', 'avahi-daemon.service'], check=True)
+            subprocess.run([SYSTEMCTL, 'is-active', 'avahi-daemon.service'], check=True)
             self.assertFalse(srv._on_kick_avahi())
         except subprocess.CalledProcessError:
             self.assertTrue(srv._on_kick_avahi())

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -98,7 +98,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
             'disconnect-trtypes = tcp+rdma+fc\n',
             'connect-attempts-on-ncc = hello\n',
         ]
-        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  # pylint: disable=unspecified-encoding
             f.writelines(data)
         service_conf.reload()
         self.assertEqual(service_conf.connect_attempts_on_ncc, 0)
@@ -108,7 +108,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
             '[Global]\n',
             'ip-family=ipv4\n',
         ]
-        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  pylint: disable=unspecified-encoding
             f.writelines(data)
         service_conf.reload()
         self.assertIn(4, service_conf.ip_family)
@@ -118,7 +118,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
             '[Global]\n',
             'ip-family=ipv4+ipv6\n',
         ]
-        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  pylint: disable=unspecified-encoding
             f.writelines(data)
         service_conf.reload()
         self.assertIn(4, service_conf.ip_family)
@@ -128,7 +128,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
             '[Global]\n',
             'ip-family=ipv6+ipv4\n',
         ]
-        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  # pylint: disable=unspecified-encoding
+        with open(StasProcessConfUnitTest.FNAME, 'w') as f:  #  pylint: disable=unspecified-encoding
             f.writelines(data)
         service_conf.reload()
         self.assertIn(4, service_conf.ip_family)
@@ -174,7 +174,7 @@ class StasSysConfUnitTest(unittest.TestCase):
     def setUpClass(cls):
         '''Create a temporary configuration file'''
         for file, data in StasSysConfUnitTest.DATA.items():
-            with open(file, 'w') as f:  #  # pylint: disable=unspecified-encoding
+            with open(file, 'w') as f:  #  pylint: disable=unspecified-encoding
                 f.writelines(data)
 
     @classmethod

--- a/test/test-iputil.py
+++ b/test/test-iputil.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 import os
 import json
+import shutil
 import logging
 import unittest
 import ipaddress
 import subprocess
 from staslib import iputil, log, trid
 
+IP = shutil.which('ip')
 
 class Test(unittest.TestCase):
     '''iputil.py unit tests'''
@@ -20,7 +22,7 @@ class Test(unittest.TestCase):
         # using standard bash utility (ip address). We'll use this to make sure
         # iputil.get_interface() returns the same data as "ip address".
         try:
-            cmd = ['ip', '-j', 'address', 'show']
+            cmd = [IP, '-j', 'address', 'show']
             p = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
             self.ifaces = json.loads(p.stdout.decode().strip())
         except subprocess.CalledProcessError:


### PR DESCRIPTION
libnvme is not multi-thread safe. Since nvme-stas uses threads we need to make sure that each thread do not share the same libnvme context (i.e. root and host objects).