### PR TITLE
udev: improve comparison between candidate and existing controllers

### DIFF
--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -574,7 +574,7 @@ class SysConf(metaclass=singleton.Singleton):
         try:
             value = self.__get_value('Host', 'key', defs.NVME_HOSTKEY)
         except FileNotFoundError as ex:
-            logging.info('Host key undefined: %s', ex)
+            logging.debug('Host key undefined: %s', ex)
             value = None
 
         return value

--- a/staslib/iputil.py
+++ b/staslib/iputil.py
@@ -29,6 +29,7 @@ NLMSG_LENGTH = lambda msg_len: msg_len + NLMSG_HDRLEN  # pylint: disable=unneces
 RTATTR_SZ = 4
 RTA_ALIGN = lambda length: ((length + 3) & ~3)  # pylint: disable=unnecessary-lambda-assignment
 IFLA_ADDRESS = 1
+IFLA_IFNAME = 3
 
 
 def _nlmsghdr(nlmsg_type, nlmsg_flags, nlmsg_seq, nlmsg_pid, msg_len: int):
@@ -193,15 +194,174 @@ def _iface_of(src_addr):  # pylint: disable=too-many-locals
 
 
 # ******************************************************************************
-def get_ipaddress_obj(ipaddr):
+def get_ipaddress_obj(ipaddr, ipv4_mapped_convert=False):
     '''@brief Return a IPv4Address or IPv6Address depending on whether @ipaddr
-    is a valid IPv4 or IPv6 address. Return None otherwise.'''
+    is a valid IPv4 or IPv6 address. Return None otherwise.
+
+    If ipv4_mapped_resolve is set to True, IPv6 addresses that are IPv4-Mapped,
+    will be converted to their IPv4 equivalent.
+    '''
     try:
         ip = ipaddress.ip_address(ipaddr)
     except ValueError:
         return None
 
+    if ipv4_mapped_convert:
+        ipv4_mapped = getattr(ip, 'ipv4_mapped', None)
+        if ipv4_mapped is not None:
+            ip = ipv4_mapped
+
     return ip
+
+
+# ******************************************************************************
+def get_primary_src_addrs(iface: str):  # pylint: disable=too-many-locals, too-many-branches
+    '''@brief Return the two primary IP addresses associated with interface @iface.
+    @param iface: The interface name to match
+    @return: tuple(primary-ipv4-addr-or-None, primary-ipv6-addr-or-None)
+    '''
+    iface_indx = None
+    interfaces = {}
+    with socket.socket(socket.AF_NETLINK, socket.SOCK_RAW) as sock:
+        sock.sendall(GETADDRCMD)
+        nlmsg = sock.recv(8192)
+        nlmsg_idx = 0
+        while True:  # pylint: disable=too-many-nested-blocks
+            if nlmsg_idx >= len(nlmsg):
+                nlmsg += sock.recv(8192)
+
+            nlmsghdr = nlmsg[nlmsg_idx : nlmsg_idx + NLMSG_HDRLEN]
+            nlmsg_len, nlmsg_type, _, _, _ = struct.unpack('<LHHLL', nlmsghdr)
+
+            if nlmsg_type == NLMSG_DONE:
+                break
+
+            if nlmsg_type == RTM_NEWADDR:
+                msg_indx = nlmsg_idx + NLMSG_HDRLEN
+                msg = nlmsg[msg_indx : msg_indx + IFADDRMSG_SZ]  # ifaddrmsg
+                ifa_family, _, _, _, ifa_index = struct.unpack('<BBBBL', msg)
+
+                interfaces.setdefault(ifa_index, {})
+
+                rtattr_indx = msg_indx + IFADDRMSG_SZ
+                while rtattr_indx < (nlmsg_idx + nlmsg_len):
+                    rtattr = nlmsg[rtattr_indx : rtattr_indx + RTATTR_SZ]
+                    rta_len, rta_type = struct.unpack('<HH', rtattr)
+
+                    if rta_type == IFLA_IFNAME:
+                        data = nlmsg[rtattr_indx + RTATTR_SZ : rtattr_indx + rta_len]
+                        ifname = data.rstrip(b'\0').decode()
+                        interfaces[ifa_index]['name'] = ifname
+                        if ifname == iface:
+                            iface_indx = ifa_index
+                            ipv4_lst = interfaces[ifa_index].get(socket.AF_INET, [])
+                            ipv6_lst = interfaces[ifa_index].get(socket.AF_INET6, [])
+                            if len(ipv4_lst) and len(ipv6_lst):
+                                return (ipv4_lst[0], ipv6_lst[0])
+
+                    elif rta_type == IFLA_ADDRESS:
+                        data = nlmsg[rtattr_indx + RTATTR_SZ : rtattr_indx + rta_len]
+                        ip = get_ipaddress_obj(data)
+                        if ip:
+                            interfaces[ifa_index].setdefault(ifa_family, []).append(ip)
+                            ifname = interfaces[ifa_index].get('name')
+                            if ifname == iface:
+                                ipv4_lst = interfaces[ifa_index].get(socket.AF_INET, [])
+                                ipv6_lst = interfaces[ifa_index].get(socket.AF_INET6, [])
+                                if len(ipv4_lst) and len(ipv6_lst):
+                                    return (ipv4_lst[0], ipv6_lst[0])
+
+                    rta_len = RTA_ALIGN(rta_len)  # Round up to multiple of 4
+                    rtattr_indx += rta_len  # Move to next rtattr
+
+            nlmsg_idx += nlmsg_len  # Move to next Netlink message
+
+    if iface_indx is not None:
+        ipv4_lst = interfaces[iface_indx].get(socket.AF_INET, [None])
+        ipv6_lst = interfaces[iface_indx].get(socket.AF_INET6, [None])
+        return (ipv4_lst[0], ipv6_lst[0])
+
+    return None, None
+
+
+# ******************************************************************************
+def net_if_addrs():  # pylint: disable=too-many-locals
+    '''@brief Return a dictionary listing every IP addresses for each interface.
+    The first IP address of a list is the primary address used as the default
+    source address.
+    @example: {
+        'wlp0s20f3': {
+             4: ['10.0.0.28'],
+             6: [
+                'fd5e:9a9e:c5bd:0:5509:890c:1848:3843',
+                'fd5e:9a9e:c5bd:0:1fd5:e527:8df7:7912',
+                '2605:59c8:6128:fb00:c083:1b8:c467:81d2',
+                '2605:59c8:6128:fb00:e99d:1a02:38e0:ad52',
+                'fe80::d71b:e807:d5ee:7614'
+             ],
+        },
+        'lo': {
+             4: ['127.0.0.1'],
+             6: ['::1'],
+        },
+        'docker0': {
+            4: ['172.17.0.1'],
+            6: []
+        },
+    }
+    '''
+    interfaces = {}
+    with socket.socket(socket.AF_NETLINK, socket.SOCK_RAW) as sock:
+        sock.sendall(GETADDRCMD)
+        nlmsg = sock.recv(8192)
+        nlmsg_idx = 0
+        while True:  # pylint: disable=too-many-nested-blocks
+            if nlmsg_idx >= len(nlmsg):
+                nlmsg += sock.recv(8192)
+
+            nlmsghdr = nlmsg[nlmsg_idx : nlmsg_idx + NLMSG_HDRLEN]
+            nlmsg_len, nlmsg_type, _, _, _ = struct.unpack('<LHHLL', nlmsghdr)
+
+            if nlmsg_type == NLMSG_DONE:
+                break
+
+            if nlmsg_type == RTM_NEWADDR:
+                msg_indx = nlmsg_idx + NLMSG_HDRLEN
+                msg = nlmsg[msg_indx : msg_indx + IFADDRMSG_SZ]  # ifaddrmsg
+                ifa_family, _, _, _, ifa_index = struct.unpack('<BBBBL', msg)
+
+                if ifa_family in (socket.AF_INET, socket.AF_INET6):
+                    interfaces.setdefault(ifa_index, {4: [], 6: []})
+
+                    rtattr_indx = msg_indx + IFADDRMSG_SZ
+                    while rtattr_indx < (nlmsg_idx + nlmsg_len):
+                        rtattr = nlmsg[rtattr_indx : rtattr_indx + RTATTR_SZ]
+                        rta_len, rta_type = struct.unpack('<HH', rtattr)
+
+                        if rta_type == IFLA_IFNAME:
+                            data = nlmsg[rtattr_indx + RTATTR_SZ : rtattr_indx + rta_len]
+                            ifname = data.rstrip(b'\0').decode()
+                            interfaces[ifa_index]['name'] = ifname
+
+                        elif rta_type == IFLA_ADDRESS:
+                            data = nlmsg[rtattr_indx + RTATTR_SZ : rtattr_indx + rta_len]
+                            ip = get_ipaddress_obj(data)
+                            if ip:
+                                family = 4 if ifa_family == socket.AF_INET else 6
+                                interfaces[ifa_index][family].append(ip)
+
+                        rta_len = RTA_ALIGN(rta_len)  # Round up to multiple of 4
+                        rtattr_indx += rta_len  # Move to next rtattr
+
+            nlmsg_idx += nlmsg_len  # Move to next Netlink message
+
+    if_addrs = {}
+    for value in interfaces.values():
+        name = value.pop('name', None)
+        if name is not None:
+            if_addrs[name] = value
+
+    return if_addrs
 
 
 # ******************************************************************************

--- a/utils/nvmet/nvmet.conf
+++ b/utils/nvmet/nvmet.conf
@@ -6,10 +6,10 @@
     'ports': [
         {
             'id': 1,
-            'adrfam': 'ipv6',
-            'traddr': '::',
-            #'adrfam': 'ipv4',
-            #'traddr': '0.0.0.0',
+            #'adrfam': 'ipv6',
+            #'traddr': '::',
+            'adrfam': 'ipv4',
+            'traddr': '0.0.0.0',
             'trsvcid': 8009,
             'trtype': 'tcp',
         }


### PR DESCRIPTION
This is so that nvme-stas can better identify existing controller connections that can be reused for new candidate controllers.

More testing is needed. Just wanted to push the changes incrementally.