### PR TITLE
test: Speed up pylint

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ endforeach
 #===========================================================================
 # Make a list of modules to lint
 modules_to_lint = [stafd, stafctl, stacd, stacctl, stasadm]
+packages_to_lint = []
 
 
 # Point Python Path to Current Build Dir.

--- a/staslib/meson.build
+++ b/staslib/meson.build
@@ -49,13 +49,4 @@ python3.install_sources(
     subdir: 'staslib',
 )
 
-#===============================================================================
-# Make a list of modules to lint
-skip = ['stafd.idl', 'stacd.idl']
-foreach file: files_to_install
-    fname = fs.name('@0@'.format(file))
-    if fname not in skip
-        modules_to_lint += file
-    endif
-endforeach
-
+packages_to_lint += meson.current_build_dir()

--- a/test/meson.build
+++ b/test/meson.build
@@ -65,7 +65,7 @@ else
         rcfile = srce_dir / 'pylint.rc'
 
         if pylint.found()
-            test('pylint', pylint, args: ['--rcfile=' + rcfile] + modules_to_lint, env: test_env)
+            test('pylint', pylint, args: ['--rcfile=' + rcfile] + modules_to_lint + packages_to_lint, env: test_env)
         else
             warning('Skiping some of the tests because "pylint" is missing.')
         endif

--- a/test/pylint.rc
+++ b/test/pylint.rc
@@ -79,7 +79,7 @@ ignored-modules=
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
-jobs=1
+jobs=0
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or


### PR DESCRIPTION
Speed up pylint by using `-j0` option and linting `staslib` as a package (directory with `__init__.py`) instead of individual modules.