### PR TITLE
Attempt to fix the mock libnvme test so it works in GitHub actions & autopkgtest

### DIFF
--- a/test/test-defs.py
+++ b/test/test-defs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import contextlib
 import os
 import sys
 import unittest
@@ -9,13 +10,17 @@ class MockLibnvmeTestCase(unittest.TestCase):
     '''Testing defs.py by mocking the libnvme package'''
 
     def test_libnvme_version(self):
-        # For unknown reasons, this test does
-        # not work when run from GitHub Actions.
-        if not os.getenv('GITHUB_ACTIONS'):
-            from staslib import defs
+        # Ensure that we re-import staslib & staslib.defs if the current Python
+        # process has them already imported.
+        with contextlib.suppress(KeyError):
+            sys.modules.pop('staslib.defs')
+        with contextlib.suppress(KeyError):
+            sys.modules.pop('staslib')
 
-            libnvme_ver = defs.LIBNVME_VERSION
-            self.assertEqual(libnvme_ver, '?.?')
+        from staslib import defs
+
+        libnvme_ver = defs.LIBNVME_VERSION
+        self.assertEqual(libnvme_ver, '?.?')
 
     @classmethod
     def setUpClass(cls):  # called once before all the tests


### PR DESCRIPTION
Different Python test frameworks manage Python processes differently when running tests. When running `python3 -m unittest` for instance, it looks like the same process executes all the tests.  Therefore when one test module T1 imports a module, the module is not re-imported if needed by T2.

This causes issues with test-defs.py which tries to mock the libnvme module. Indeed, when it is previously imported by staslib, the mocked libnvme module does not get re-imported.

This is an attempt to fix the test by removing staslib and staslib.defs from the imported modules before executing the test.