### PR TITLE
test: Fix test-udev failing when multiple IPv6 addresses are used

### DIFF
--- a/test/test-udev.py
+++ b/test/test-udev.py
@@ -679,7 +679,7 @@ class Test(unittest.TestCase):
                         'host-nqn': '',
                     }
                 )
-                match = len(ipv6_addrs) == 1 and iputil.get_ipaddress_obj(
+                match = len(ipv6_addrs) >= 1 and iputil.get_ipaddress_obj(
                     ipv6_addrs[0], ipv4_mapped_convert=True
                 ) == iputil.get_ipaddress_obj(tid.host_traddr, ipv4_mapped_convert=True)
                 self.assertEqual(


### PR DESCRIPTION
test-udev was failing when an interface had more than one IPv6 addresses assigned. This was due to the test checking that the number of assigned IPv6 addresses was exactly 1 (== 1) instead of checking greater-equal to 1 (>= 1).