### PR TITLE
systemd: Harden stafd/stacd service files

### DIFF
--- a/usr/lib/systemd/system/stacd.in.service
+++ b/usr/lib/systemd/system/stacd.in.service
@@ -28,5 +28,14 @@ RuntimeDirectory=stacd
 CacheDirectory=stacd
 RuntimeDirectoryPreserve=yes
 
+ProtectHome=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectProc=invisible
+RestrictRealtime=true
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/system/stafd.in.service
+++ b/usr/lib/systemd/system/stafd.in.service
@@ -31,5 +31,14 @@ RuntimeDirectory=stafd
 CacheDirectory=stafd
 RuntimeDirectoryPreserve=yes
 
+ProtectHome=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectProc=invisible
+RestrictRealtime=true
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Following nvme-cli's example by making `stafd.service` and `stacd.service` more secure.

Ref: https://github.com/linux-nvme/nvme-cli/pull/2284