### PR TITLE
Build: Fix Github actions

### DIFF
--- a/.github/workflows/meson-test.yml
+++ b/.github/workflows/meson-test.yml
@@ -15,21 +15,31 @@ jobs:
       - name: "CHECKOUT: nvme-stas"
         uses: actions/checkout@v4
 
-      - name: "INSTALL: Overall dependencies"
+      - name: "INSTALL: build packages"
         run: |
           sudo apt update
-          sudo apt-get install --yes --quiet python3-pip cmake iproute2
-          sudo python3 -m pip install --upgrade pip
-          sudo python3 -m pip install --upgrade wheel meson ninja
+          sudo apt-get install --yes --quiet meson ninja-build cmake
 
-      - name: "INSTALL: nvme-stas dependencies"
+      - name: "INSTALL: python packages"
         run: |
-          sudo apt-get install --yes --quiet docbook-xml docbook-xsl xsltproc libglib2.0-dev libgirepository1.0-dev libsystemd-dev
-          sudo apt-get install --yes --quiet python3-systemd python3-pyudev python3-lxml
-          python3 -m pip install --upgrade dasbus pylint pyflakes PyGObject
-          python3 -m pip install --upgrade vermin pyfakefs importlib-resources
+          sudo apt update
+          sudo apt-get install --yes --quiet python3-pip python3-wheel pylint pyflakes3 python3-systemd python3-pyudev python3-lxml python3-dasbus python3-gi python3-importlib-resources python3-pyfakefs
 
-      - name: "INSTALL: libnvme dependencies"
+      - name: "INSTALL: documentation packages"
+        run: |
+          sudo apt update
+          sudo apt-get install --yes --quiet docbook-xml docbook-xsl xsltproc
+
+      - name: "INSTALL: remaining debian packages"
+        run: |
+          sudo apt update
+          sudo apt-get install --yes --quiet iproute2 libglib2.0-dev libgirepository1.0-dev libsystemd-dev
+
+      - name: "INSTALL: pip packages"
+        run: |
+          sudo pip install vermin --break-system-packages
+
+      - name: "INSTALL: libnvme packages (needed to build libnvme)"
         run: |
           sudo apt-get install --yes --quiet swig libjson-c-dev
 
@@ -54,8 +64,7 @@ jobs:
 
       - name: "Generate coverage report"
         run: |
-          python3 -m pip install --upgrade pytest
-          python3 -m pip install --upgrade pytest-cov
+          sudo apt-get install python3-pytest python3-pytest-cov
           echo $( pwd )
           cp -r .build/staslib/* ./staslib/.
           pytest --cov=./staslib --cov-report=xml test/test-*.py

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: "CHECKOUT: nvme-stas"
@@ -37,12 +37,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: "INSTALL: additional packages"
+      - name: "INSTALL: apt-get packages"
         run: |
           sudo apt update
-          sudo apt-get install --yes --quiet python3-pip cmake libgirepository1.0-dev libsystemd-dev python3-systemd swig libjson-c-dev || true
-          sudo python3 -m pip install --upgrade pip wheel meson ninja
-          python3 -m pip install --upgrade dasbus pylint pyflakes PyGObject lxml pyudev
+          sudo apt-get install --yes --quiet meson ninja-build cmake libgirepository1.0-dev libsystemd-dev swig libjson-c-dev
+          sudo apt-get install --yes --quiet python3-wheel python3-systemd python3-pyudev python3-dasbus python3-gi python3-lxml pylint pyflakes3 python3-pyflakes python3-tomli
+
+      - name: "INSTALL: pip packages"
+        run: |
+          sudo pip install PyGObject --break-system-packages
 
       - name: "BUILD: [libnvme, nvme-stas]"
         uses: BSFishy/meson-build@v1.0.3
@@ -60,12 +63,12 @@ jobs:
           echo -e "Build Directory:\n$(ls -laF .build)"
           python3 -VV
           python3 -m site
-          python3 -m pylint --version
+          pylint --version
           echo "pyflakes $(python3 -m pyflakes --version)"
 
       - name: Pylint
         run: |
-          python3 -m pylint -j 0 --rcfile=test/pylint.rc .build/stacctl .build/stacd .build/stafctl .build/stafd .build/stasadm .build/staslib
+          pylint -j 0 --rcfile=test/pylint.rc .build/stacctl .build/stacd .build/stafctl .build/stafd .build/stasadm .build/staslib
 
       - name: Pyflakes
         if: always()

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,8 +20,6 @@ build:
     - xsltproc
     - pandoc
   jobs:
-    post_install:
-      - pip3 install lxml
     pre_build:
       - meson .build -Dreadthedocs=true || cat .build/meson-logs/meson-log.txt
       - ninja -C .build

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ black:
 	black --diff --color --line-length 120 --skip-string-normalization --extend-exclude="(subprojects|debian|.build)" .
 
 # Coverage requirements:
-#   pip install coverage
+#   apt-get install python3-coverage
 .PHONY: coverage
 coverage: stas
 	cd ${BUILD-DIR} && ./coverage.sh

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following packages must be installed to use **`stafd`**/**`stacd`**
 sudo apt-get install -y python3-pyudev python3-systemd python3-gi
 sudo apt-get install -y python3-dasbus # Ubuntu 22.04
 OR:
-sudo pip3 install dasbus # Ubuntu 20.04
+sudo pip install dasbus # Ubuntu 20.04 (may require --break-system-packages)
 ```
 
 **RPM packages (tested on Fedora 34..35 and SLES15):**

--- a/TESTING.md
+++ b/TESTING.md
@@ -184,7 +184,7 @@ $ sudo ./nvmet.py clean
 This requires the [Python coverage package](https://coverage.readthedocs.io/en/6.4.1/), which can be installed as follows:
 
 ```bash
-$ sudo pip install coverage
+$ sudo apt-get install python3-coverage
 ```
 
 Note that this test cannot be run while `stafd` and `stacd` are running. Make sure to stop `stafd` and `stacd` if they are running (`systemctl stop [stafd|stacd]`). You may also need to mask those services (`systemctl mask [stafd|stacd]`) if coverage fails to start. 

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ endif
 missing_runtime_mods = false
 py_modules_reqd = [
     ['libnvme', 'Install python3-libnvme (deb/rpm)'],
-    ['dasbus',  'Install python3-dasbus (deb/rpm) OR pip3 install dasbus'],
+    ['dasbus',  'Install python3-dasbus (deb/rpm) OR pip install dasbus'],
     ['pyudev',  'Install python3-pyudev (deb/rpm)'],
     ['systemd', 'Install python3-systemd (deb/rpm)'],
     ['gi',      'Install python3-gi (deb) OR python3-gobject (rpm)'],

--- a/utils/nvmet/nvmet.conf
+++ b/utils/nvmet/nvmet.conf
@@ -6,10 +6,10 @@
     'ports': [
         {
             'id': 1,
-            'adrfam': 'ipv6',
-            'traddr': '::',
-            #'adrfam': 'ipv4',
-            #'traddr': '0.0.0.0',
+            #'adrfam': 'ipv6',
+            #'traddr': '::',
+            'adrfam': 'ipv4',
+            'traddr': '0.0.0.0',
             'trsvcid': 8009,
             'trtype': 'tcp',
         }


### PR DESCRIPTION
The environment used to run GitHub actions has been updated upstream, which breaks the build. This is mainly due to the use of pip. That is, the use of upstream pip and not the one provided by Debian through apt-get install python3-pip.

This updates all the build scripts to use the standard Debian packages (if available) and not rely on "pip install".