### PR TITLE
staslib: rename dhchap to kxchap

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -384,7 +384,7 @@ zeroconf-connections-persistence = 0.5
 zeroconf = enabled
 
 [Controllers]
-controller=transport=tcp;traddr=localhost;trsvcid=8009;kato=31;dhchap-ctrl-secret=DHHC-1:00:not-so-secret/not-so-secret/not-so-secret/not-so:;dhchap-secret=DHHC-1:00:very-secret/very-secret/very-secret/very-secret/:
+controller=transport=tcp;traddr=localhost;trsvcid=8009;kato=31;kxchap-ctrl-secret=DHHC-1:00:not-so-secret/not-so-secret/not-so-secret/not-so:;kxchap-secret=DHHC-1:00:very-secret/very-secret/very-secret/very-secret/:
 EOF
 log_file_contents 0 "${stafd_conf_fname}"
 printf "\n"
@@ -409,7 +409,7 @@ persistent-connections            = false
 zeroconf-connections-persistence  = 1:01
 
 [Controllers]
-controller = transport = tcp ; traddr = localhost ; ; ; kato=31; dhchap-ctrl-secret=DHHC-1:00:not-so-secret/not-so-secret/not-so-secret/not-so: ; dhchap-secret=DHHC-1:00:very-secret/very-secret/very-secret/very-secret/:
+controller = transport = tcp ; traddr = localhost ; ; ; kato=31; kxchap-ctrl-secret=DHHC-1:00:not-so-secret/not-so-secret/not-so-secret/not-so: ; kxchap-secret=DHHC-1:00:very-secret/very-secret/very-secret/very-secret/:
 controller=transport=tcp;traddr=1.1.1.1
 controller=transport=tcp;traddr=100.100.100.100
 controller=transport=tcp;traddr=2607:f8b0:4002:c2c::71

--- a/doc/standard-conf.xml
+++ b/doc/standard-conf.xml
@@ -376,8 +376,8 @@
                             </listitem>
                         </varlistentry>
 
-                        <varlistentry id='dhchap-secret'>
-                            <term><varname>dhchap-secret=</varname></term>
+                        <varlistentry id='kxchap-secret'>
+                            <term><varname>kxchap-secret=</varname></term>
                             <listitem>
                                 <para>
                                     NVMe In-band authentication host secret (i.e. key);
@@ -391,8 +391,8 @@
                             </listitem>
                         </varlistentry>
 
-                        <varlistentry id='dhchap-ctrl-secret'>
-                            <term><varname>dhchap-ctrl-secret=</varname></term>
+                        <varlistentry id='kxchap-ctrl-secret'>
+                            <term><varname>kxchap-ctrl-secret=</varname></term>
                             <listitem>
                                 <para>
                                     This is an optional field that specifies the

--- a/etc/stas/stacd.conf
+++ b/etc/stas/stacd.conf
@@ -235,7 +235,7 @@
 #               This forces the connection to be made on a specific interface
 #               instead of letting the system decide.
 #
-#             dhchap-secret         [OPTIONAL]
+#             kxchap-secret         [OPTIONAL]
 #               NVMe In-band authentication host secret (i.e. key); needs to be
 #               in ASCII format as specified in NVMe 2.0 section 8.13.5.8 Secret
 #               representation. If this option is not specified, the default is
@@ -243,7 +243,7 @@
 #               [Host] section). In-band authentication is attempted when this
 #               is present.
 #
-#             dhchap-ctrl-secret    [OPTIONAL]
+#             kxchap-ctrl-secret    [OPTIONAL]
 #               NVMe In-band authentication controller secret (i.e. key) for
 #               bi-directional authentication; needs to be in ASCII format as
 #               specified in NVMe 2.0 section 8.13.5.8 'Secret representation'.

--- a/etc/stas/stafd.conf
+++ b/etc/stas/stafd.conf
@@ -210,7 +210,7 @@
 #               This forces the connection to be made on a specific interface
 #               instead of letting the system decide.
 #
-#             dhchap-secret         [OPTIONAL]
+#             kxchap-secret         [OPTIONAL]
 #               NVMe In-band authentication host secret (i.e. key); needs to be
 #               in ASCII format as specified in NVMe 2.0 section 8.13.5.8 Secret
 #               representation. If this option is not specified, the default is

--- a/etc/stas/sys.conf.doc
+++ b/etc/stas/sys.conf.doc
@@ -36,7 +36,7 @@
 #id=file:///etc/nvme/hostid
 
 
-# key:     The host's DHCHAP key to be used for authentication. This is an
+# key:     The host's KXCHAP key to be used for authentication. This is an
 #          optional parameter only required when authentication is needed.
 #          A value starting with "file://" indicates that the Host Key can
 #          be retrieved from a separate file. Typically, nvme-cli saves the

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -332,8 +332,8 @@ class SvcConf(metaclass=singleton.Singleton):
             'host-traddr':        [TRADDR],
             'host-iface':         [IFACE],
             'host-nqn':           [NQN],
-            'dhchap-secret':      [KEY],
-            'dhchap-ctrl-secret': [KEY],
+            'kxchap-secret':      [KEY],
+            'kxchap-ctrl-secret': [KEY],
             'hdr-digest':         [BOOL]
             'data-digest':        [BOOL]
             'nr-io-queues':       [NUMBER]
@@ -554,7 +554,7 @@ class SysConf(metaclass=singleton.Singleton):
 
     @property
     def hostkey(self):
-        '''Return the host DH-CHAP key, or None if not configured.
+        '''Return the host KXCHAP key, or None if not configured.
         The key is optional unless in-band authentication is required.'''
         try:
             value = self.__get_value('Host', 'key', defs.NVME_HOSTKEY)
@@ -619,6 +619,10 @@ class NvmeOptions(metaclass=singleton.Singleton):
         # have been backported to older kernels. In any case, if the kernel
         # version meets the minimum version for that option, then we don't
         # even need to read '/dev/nvme-fabrics'.
+        #
+        # The keys must match the option names the kernel prints in
+        # '/dev/nvme-fabrics'. TP4201 renamed DHCHAP to KXCHAP in the libnvme
+        # API, but the kernel option names are unchanged.
         self._supported_options = {
             'discovery': defs.KERNEL_VERSION >= defs.KERNEL_TP8013_MIN_VERSION,
             'host_iface': defs.KERNEL_VERSION >= defs.KERNEL_IFACE_MIN_VERSION,
@@ -663,13 +667,13 @@ class NvmeOptions(metaclass=singleton.Singleton):
         return self._supported_options['host_iface']
 
     @property
-    def dhchap_hostkey_supp(self):
-        '''This option allows specifying the host DHCHAP key used for authentication.'''
+    def kxchap_hostkey_supp(self):
+        '''This option allows specifying the host KXCHAP key used for authentication.'''
         return self._supported_options['dhchap_secret']
 
     @property
-    def dhchap_ctrlkey_supp(self):
-        '''This option allows specifying the controller DHCHAP key used for authentication.'''
+    def kxchap_ctrlkey_supp(self):
+        '''This option allows specifying the controller KXCHAP key used for authentication.'''
         return self._supported_options['dhchap_ctrl_secret']
 
 

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -56,7 +56,7 @@ class Controller(stas.ControllerABC):
         self._host = nvme.Host(
             self._ctx, hostnqn=sysconf.hostnqn, hostid=sysconf.hostid, hostsymname=sysconf.hostsymname
         )
-        self._host.dhchap_host_key = sysconf.hostkey if self._nvme_options.dhchap_hostkey_supp else None
+        self._host.kxchap_host_key = sysconf.hostkey if self._nvme_options.kxchap_hostkey_supp else None
         self._udev = udev.UDEV
         self._device = None  # Refers to the nvme device (e.g. /dev/nvme[n])
         self._ctrl = None  # libnvme's nvme.Ctrl object
@@ -224,21 +224,21 @@ class Controller(stas.ControllerABC):
 
         self._ctrl.discovery_ctrl = self._discovery_ctrl
 
-        # Set the DHCHAP host key on the controller
+        # Set the KXCHAP host key on the controller
         # NOTE that this may eventually have to
         # change once we have support for AVE (TP8019)
         # This is used for in-band authentication
-        dhchap_host_key = self.tid.cfg.get('dhchap-secret')
-        if dhchap_host_key and self._nvme_options.dhchap_hostkey_supp:
-            self._ctrl.dhchap_host_key = dhchap_host_key
+        kxchap_host_key = self.tid.cfg.get('kxchap-secret')
+        if kxchap_host_key and self._nvme_options.kxchap_hostkey_supp:
+            self._ctrl.kxchap_host_key = kxchap_host_key
 
-        # Set the DHCHAP controller key on the controller
+        # Set the KXCHAP controller key on the controller
         # NOTE that this may eventually have to
         # change once we have support for AVE (TP8019)
         # This is used for bidirectional authentication
-        dhchap_ctrl_key = self.tid.cfg.get('dhchap-ctrl-secret')
-        if dhchap_ctrl_key and self._nvme_options.dhchap_ctrlkey_supp:
-            self._ctrl.dhchap_ctrl_key = dhchap_ctrl_key
+        kxchap_ctrl_key = self.tid.cfg.get('kxchap-ctrl-secret')
+        if kxchap_ctrl_key and self._nvme_options.kxchap_ctrlkey_supp:
+            self._ctrl.kxchap_ctrl_key = kxchap_ctrl_key
 
         # Audit existing nvme devices. If we find a match, then
         # we'll just borrow that device instead of creating a new one.

--- a/staslib/trid.py
+++ b/staslib/trid.py
@@ -38,8 +38,8 @@ class TID:
             'host-nqn':    str, # [optional]
 
             # Connection parameters
-            'dhchap-secret':      str, # [optional]
-            'dhchap-ctrl-secret': str, # [optional]
+            'kxchap-secret':      str, # [optional]
+            'kxchap-ctrl-secret': str, # [optional]
             'hdr-digest':         str, # [optional]
             'data-digest':        str, # [optional]
             'nr-io-queues':       str, # [optional]

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -25,7 +25,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
             '\n',
             '[Controllers]\n',
             'controller=transport=tcp;traddr=100.100.100.100;host-iface=enp0s8\n',
-            'controller=transport=tcp;traddr=100.100.100.200;host-iface=enp0s7;dhchap-ctrl-secret=super-secret;hdr-digest=true;data-digest=true;nr-io-queues=8;nr-write-queues=6;nr-poll-queues=4;queue-size=400;kato=71;reconnect-delay=13;ctrl-loss-tmo=666;disable-sqflow=true\n',
+            'controller=transport=tcp;traddr=100.100.100.200;host-iface=enp0s7;kxchap-ctrl-secret=super-secret;hdr-digest=true;data-digest=true;nr-io-queues=8;nr-write-queues=6;nr-poll-queues=4;queue-size=400;kato=71;reconnect-delay=13;ctrl-loss-tmo=666;disable-sqflow=true\n',
             'exclude=transport=tcp;traddr=10.10.10.10\n',
         ]
         with open(StasProcessConfUnitTest.FNAME, 'w') as f:
@@ -91,7 +91,7 @@ class StasProcessConfUnitTest(unittest.TestCase):
                     'transport': 'tcp',
                     'traddr': '100.100.100.200',
                     'host-iface': 'enp0s7',
-                    'dhchap-ctrl-secret': 'super-secret',
+                    'kxchap-ctrl-secret': 'super-secret',
                     'hdr-digest': True,
                     'data-digest': True,
                     'nr-io-queues': 8,
@@ -276,7 +276,7 @@ class TestParseController(unittest.TestCase):
         self.assertEqual(result, {})
 
     def test_token_with_extra_equals_preserves_value(self):
-        # split('=', maxsplit=1) keeps extra '=' in value (needed for base64-padded DH-CHAP secrets)
+        # split('=', maxsplit=1) keeps extra '=' in value (needed for base64-padded KXCHAP secrets)
         result = conf._parse_controller('key=val=extra')
         self.assertEqual(result, {'key': 'val=extra'})
 

--- a/test/test-nvme_options.py
+++ b/test/test-nvme_options.py
@@ -67,8 +67,8 @@ class Test(TestCase):
         nvme_options = conf.NvmeOptions()
         self.assertTrue(nvme_options.discovery_supp)
         self.assertTrue(nvme_options.host_iface_supp)
-        self.assertTrue(nvme_options.dhchap_hostkey_supp)
-        self.assertTrue(nvme_options.dhchap_ctrlkey_supp)
+        self.assertTrue(nvme_options.kxchap_hostkey_supp)
+        self.assertTrue(nvme_options.kxchap_ctrlkey_supp)
         self.assertEqual(
             nvme_options.get(),
             {'discovery': True, 'host_iface': True, 'dhchap_secret': True, 'dhchap_ctrl_secret': True},

--- a/utils/nvmet/auth.conf
+++ b/utils/nvmet/auth.conf
@@ -24,7 +24,7 @@
                 {
                     # Must match with the NQN and key configured on the host
                     # Key was generated with:
-                    #    nvme gen-dhchap-key ...
+                    #    nvme keys gen-kxchap-secret ...
                     'nqn': 'nqn.2014-08.org.nvmexpress:uuid:46ba5037-7ce5-41fa-9452-48477bf00080',
                     'key': 'DHHC-1:00:2kx1hDTUPdvwtxHYUXFRl8pzn5hYZH7K3Z77IYM4hNN6/fQT:',
                 },


### PR DESCRIPTION
TP4201 renames crypto related definitions/fields. libnvme commit 76563574b ("libnvme: rename dhchp to kxchap") renamed the Python binding attributes, which broke every Controller construction with "AttributeError: 'Host' has no attribute 'dhchap_host_key'".

Rename the nvme-stas configuration keys to match. The kernel option names in '/dev/nvme-fabrics' and the nvmet configfs attributes are unchanged.