### PR TITLE
staslib: take TLS parameters from nvme-cli's configuration file

### DIFF
--- a/doc/stacd.conf.xml
+++ b/doc/stacd.conf.xml
@@ -143,6 +143,7 @@
                 <xi:include href="standard-conf.xml" xpointer="reconnect-delay"/>
                 <xi:include href="standard-conf.xml" xpointer="ctrl-loss-tmo"/>
                 <xi:include href="standard-conf.xml" xpointer="disable-sqflow"/>
+                <xi:include href="standard-conf.xml" xpointer="nvme-config-file"/>
 
                 <varlistentry>
                     <term><varname>ignore-iface=</varname></term>

--- a/doc/stafd.conf.xml
+++ b/doc/stafd.conf.xml
@@ -89,6 +89,7 @@
                 <xi:include href="standard-conf.xml" xpointer="reconnect-delay"/>
                 <xi:include href="standard-conf.xml" xpointer="ctrl-loss-tmo"/>
                 <xi:include href="standard-conf.xml" xpointer="disable-sqflow"/>
+                <xi:include href="standard-conf.xml" xpointer="nvme-config-file"/>
 
                 <varlistentry>
                     <term><varname>ignore-iface=</varname></term>

--- a/doc/standard-conf.xml
+++ b/doc/standard-conf.xml
@@ -173,6 +173,47 @@
                 </para>
             </listitem>
         </varlistentry>
+
+        <varlistentry id='nvme-config-file'>
+            <term><varname>nvme-config-file=</varname></term>
+
+            <listitem id='nvme-config-file-text'>
+                <para>
+                    Takes a file name. This is nvme-cli's connection
+                    configuration file, <citerefentry
+                    project='nvme-cli'><refentrytitle>nvme-fabrics.conf</refentrytitle>
+                    <manvolnum>5</manvolnum></citerefentry>, from which
+                    <parameter>tls</parameter>,
+                    <parameter>concat</parameter>,
+                    <parameter>keyring</parameter>,
+                    <parameter>tls-key</parameter> and
+                    <parameter>tls-key-identity</parameter> are taken for
+                    controllers that the file has an entry for. These security
+                    parameters have no equivalent in this file, and a
+                    TLS-secured connection cannot be established without them.
+                    All other parameters in that file are ignored: connection
+                    parameters come from this file, as usual.
+                </para>
+
+                <para>
+                    The TLS PSK named by <parameter>tls-key</parameter> is
+                    handed to libnvme only while the kernel keyring holds no
+                    key for that host and subsystem; from then on libnvme and
+                    the kernel find the retained PSK by its identity. Importing
+                    it on every connect would revoke the key the already
+                    connected controllers were given, and their next reconnect
+                    would fail the TLS handshake.
+                </para>
+
+                <para>
+                    Set it to an empty value to not read any such file.
+                </para>
+
+                <para>
+                    Defaults to <parameter>/etc/nvme/nvme-fabrics.conf</parameter>.
+                </para>
+            </listitem>
+        </varlistentry>
     </variablelist>
 
     <refsect2 id='controller'>

--- a/etc/stas/stacd.conf
+++ b/etc/stas/stacd.conf
@@ -89,6 +89,17 @@
 #                    Default: false
 #disable-sqflow=false
 
+# nvme-config-file:  nvme-cli's connection configuration file, from which the
+#                    security parameters (tls, concat, keyring, tls-key and
+#                    tls-key-identity) are taken for the controllers it has an
+#                    entry for. Those have no equivalent in this file, and a
+#                    TLS-secured connection cannot be made without them. All
+#                    the other parameters in that file are ignored.
+#                    See nvme-fabrics.conf(5).
+#                    Type:  string (file name; empty to read no such file)
+#                    Default: /etc/nvme/nvme-fabrics.conf
+#nvme-config-file=/etc/nvme/nvme-fabrics.conf
+
 # ignore-iface: This option controls whether connections with I/O Controllers
 #               (IOC) will be forced on a specific interface or will rely on
 #               the routing tables to determine the interface.

--- a/etc/stas/stafd.conf
+++ b/etc/stas/stafd.conf
@@ -69,6 +69,17 @@
 #                    Default: false
 #disable-sqflow=false
 
+# nvme-config-file:  nvme-cli's connection configuration file, from which the
+#                    security parameters (tls, concat, keyring, tls-key and
+#                    tls-key-identity) are taken for the controllers it has an
+#                    entry for. Those have no equivalent in this file, and a
+#                    TLS-secured connection cannot be made without them. All
+#                    the other parameters in that file are ignored.
+#                    See nvme-fabrics.conf(5).
+#                    Type:  string (file name; empty to read no such file)
+#                    Default: /etc/nvme/nvme-fabrics.conf
+#nvme-config-file=/etc/nvme/nvme-fabrics.conf
+
 # ignore-iface: This option controls whether connections with Discovery
 #               Controllers (DC) will be forced on a specific interface or
 #               will rely on the routing tables to determine the interface.

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -165,6 +165,10 @@ class SvcConf(metaclass=singleton.Singleton):
             'reconnect-delay': {
                 'convert': _to_int,
             },
+            'nvme-config-file': {
+                'convert': _parse_single_val,
+                'default': '/etc/nvme/nvme-fabrics.conf',
+            },
         },
         'Service Discovery': {
             'zeroconf': {
@@ -278,6 +282,7 @@ class SvcConf(metaclass=singleton.Singleton):
     nr_poll_queues = property(functools.partial(get_option, section='Global', option='nr-poll-queues'))
     nr_write_queues = property(functools.partial(get_option, section='Global', option='nr-write-queues'))
     reconnect_delay = property(functools.partial(get_option, section='Global', option='reconnect-delay'))
+    nvme_config_file = property(functools.partial(get_option, section='Global', option='nvme-config-file'))
 
     zeroconf_persistence_sec = property(
         functools.partial(

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -11,6 +11,7 @@ Dc (Discovery Controller) and Ioc (I/O Controller) objects are derived.'''
 
 import time
 import logging
+import threading
 from typing import Optional
 from gi.repository import GLib
 from libnvme3 import nvme
@@ -41,6 +42,129 @@ def dlp_supp_opts_as_string(dlp_supp_opts: int):
         nvme.NVMF_LOG_DISC_LID_ALLSUBES: "ALLSUBES",
     }
     return [txt for msk, txt in data.items() if dlp_supp_opts & msk]
+
+
+# Security parameters that can only be configured in nvme-cli's connection
+# configuration file, nvme-fabrics.conf(5). stafd.conf and stacd.conf have no
+# equivalent, and a TLS-secured connection cannot be established without them.
+# Both tables map the configuration file's key to the libnvme name.
+#
+# These two are part of the fabrics config and go in the nvme.Ctrl() dict.
+SECURITY_CFG_PARAMS = {
+    'tls': 'tls',
+    'concat': 'concat',
+}
+
+# These must be set on the nvme.Ctrl object instead: libnvmf_create_ctrl()
+# only copies the fabrics config, so a key passed in the dict is silently
+# dropped and the connect then fails with ENOKEY.
+SECURITY_ATTR_PARAMS = {
+    'keyring': 'keyring',
+    'tls-key': 'tls_key',
+    'tls-key-identity': 'tls_key_identity',
+}
+
+BOOL_PARAMS = ('tls', 'concat')
+
+# libnvme imports the TLS PSK into the keyring on every connect
+# (__libnvmf_import_keys_from_config()), and libnvmf_update_key() revokes
+# whatever key currently holds that identity before adding the replacement.
+# Connections are made from a thread pool (gutil.AsyncTask), so concurrent
+# connects would revoke each other's key serial and fail with EKEYREVOKED
+# ("Key has been revoked") or ENOKEY ("pre-shared TLS key is missing").
+# Serializing keeps each import/connect pair atomic. Connections that do not
+# use TLS don't touch the keyring and are still made in parallel.
+TLS_CONNECT_LOCK = threading.Lock()
+
+
+def _to_bool(text: str) -> bool:
+    '''Convert a boolean value as spelled in nvme-fabrics.conf(5).'''
+    return text.strip().lower() in ('1', 'y', 'yes', 't', 'true', 'on')
+
+
+def _same_controller(entry: dict, tid: trid.TID) -> bool:
+    '''Return True if @entry, a connection read from nvme-cli's connection
+    configuration file, designates the same controller as @tid. Parameters
+    that the entry leaves out (e.g. host-iface) match anything.'''
+    return all(
+        entry.get(key, '') in ('', value)
+        for key, value in (
+            ('transport', tid.transport),
+            ('traddr', tid.traddr),
+            ('trsvcid', tid.trsvcid),
+            ('subsysnqn', tid.subsysnqn),
+            ('host_traddr', tid.host_traddr),
+            ('host_iface', tid.host_iface),
+            ('hostnqn', tid.host_nqn),
+        )
+    )
+
+
+def _psk_in_keyring(hostnqn: str, subsysnqn: str) -> bool:
+    '''Return True if the kernel keyring already holds a usable TLS PSK for
+    this (host, subsystem) pair. Both libnvme and the kernel find the key by
+    its identity, e.g. "NVMe1R01 <hostnqn> <subsysnqn> <hash-of-the-key>".'''
+    marker = f' {hostnqn} {subsysnqn} '
+    try:
+        with open('/proc/keys') as f:  # pylint: disable=unspecified-encoding
+            for line in f:
+                # <serial> <flags> <usage> <timeout> <perm> <uid> <gid> <type> <description>
+                fields = line.split(None, 8)
+                if len(fields) > 8 and fields[7] == 'psk' and 'R' not in fields[1] and marker in fields[8]:
+                    return True
+    except OSError as ex:
+        logging.warning('Cannot read /proc/keys: %s', ex)
+
+    return False
+
+
+def get_security_cfg(ctx, tid: trid.TID) -> dict:
+    '''Return the security parameters that nvme-cli's connection configuration
+    file defines for the controller identified by @tid. Returns an empty dict
+    when that file has no entry for @tid.'''
+    cfg_file = conf.SvcConf().nvme_config_file
+    if not cfg_file:
+        return {}
+
+    try:
+        entries = nvme.config_read(ctx, cfg_file)
+    except OSError as ex:
+        logging.warning('Failed to read %s: %s', cfg_file, ex)
+        return {}
+
+    for entry in entries:
+        if not _same_controller(entry, tid):
+            continue
+
+        params = entry.get('params', {})
+        return {
+            # An empty value means "reset to the kernel default"
+            keyword: _to_bool(params[key]) if key in BOOL_PARAMS else params[key]
+            for key, keyword in list(SECURITY_CFG_PARAMS.items()) + list(SECURITY_ATTR_PARAMS.items())
+            if params.get(key)
+        }
+
+    return {}
+
+
+def _connect(ctrl, host, serialize: bool):
+    '''Establish the connection to @ctrl. TLS connections are serialized,
+    see TLS_CONNECT_LOCK.'''
+    if not serialize:
+        return ctrl.connect(host)
+
+    with TLS_CONNECT_LOCK:
+        # libnvme imports the PSK on every connect that carries one, and each
+        # import revokes the key handed to the controllers that are already
+        # connected - their next kernel-side reconnect then fails the TLS
+        # handshake. So hand over the key only while the keyring has none for
+        # this (host, subsystem) pair; from then on both libnvme and the
+        # kernel find it by identity. This must happen under the lock: the
+        # decision is only valid as long as no other connect can import.
+        if ctrl.tls_key and _psk_in_keyring(host.hostnqn, ctrl.subsysnqn):
+            ctrl.tls_key = None
+
+        return ctrl.connect(host)
 
 
 # ******************************************************************************
@@ -220,7 +344,17 @@ class Controller(stas.ControllerABC):
 
     def _do_connect(self):
         cfg = self._get_cfg()
+
+        # Security parameters (TLS) come from nvme-cli's configuration file
+        security = get_security_cfg(self._ctx, self.tid)
+        cfg.update({keyword: security[keyword] for keyword in SECURITY_CFG_PARAMS.values() if keyword in security})
+
         self._ctrl = nvme.Ctrl(self._ctx, cfg)
+
+        # The keys are not part of the fabrics config and must be set here
+        for keyword in SECURITY_ATTR_PARAMS.values():
+            if keyword in security:
+                setattr(self._ctrl, keyword, security[keyword])
 
         self._ctrl.discovery_ctrl = self._discovery_ctrl
 
@@ -261,7 +395,7 @@ class Controller(stas.ControllerABC):
                 'Controller._do_connect()           - %s Connecting to nvme control with cfg=%s', self.id, cfg
             )
             self._connect_op = gutil.AsyncTask(
-                self._on_connect_success, self._on_connect_fail, self._ctrl.connect, self._host
+                self._on_connect_success, self._on_connect_fail, _connect, self._ctrl, self._host, cfg.get('tls', False)
             )
 
         self._connect_op.run_async()

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import logging
 import unittest
+from unittest.mock import patch
 from libnvme3 import nvme
 from staslib import conf, ctrl, timeparse, trid
 from pyfakefs.fake_filesystem_unittest import TestCase
@@ -432,6 +433,142 @@ class Test(TestCase):
 
         # _should_try_to_reconnect: ncc=False → max_connect_attempts=0 → always True
         self.assertTrue(ioc._should_try_to_reconnect())
+
+
+class TestSecurityCfg(TestCase):
+    '''Unit tests for the security parameters that stafd/stacd take from
+    nvme-cli's connection configuration file, nvme-fabrics.conf(5)'''
+
+    HOSTNQN = 'nqn.1988-11.com.dell:poweredge:1234'
+    SUBSYSNQN = 'nqn.1988-11.com.dell:SFSS:2:20220208134025e8'
+    PSK = 'NVMeTLSkey-1:01:JbYnhWFLmpF1qLGkGSTWvXWfCEQz2vSJn3vJZ9GjPFI=:'
+    IDENTITY = 'NVMe1R01 ' + HOSTNQN + ' ' + SUBSYSNQN + ' JbYnhWFLmpF1qLGkGSTWvXWfCEQz2vSJn3vJZ9GjPFI='
+
+    # Lines as the kernel formats them in /proc/keys:
+    # <serial> <flags> <usage> <timeout> <perm> <uid> <gid> <type> <description>
+    KEY_LIVE = '37ccdd59 I--Q---     2 perm 3b010000     0     0 psk       ' + IDENTITY + ': 32\n'
+    KEY_REVOKED = '1c2700b9 IR-Q---     1 expd 3b010000     0     0 psk       ' + IDENTITY + ': 0\n'
+    KEYRING = '1959e543 ---lswrv     6 perm 3f030000     0     0 keyring   .nvme: 1\n'
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.create_file('/etc/nvme/hostnqn', contents=self.HOSTNQN + '\n')
+        self.fs.create_file('/etc/nvme/hostid', contents='01234567-89ab-cdef-0123-456789abcdef\n')
+
+        self.tid = trid.TID(
+            {
+                'transport': 'tcp',
+                'traddr': '10.10.10.10',
+                'trsvcid': '4420',
+                'subsysnqn': self.SUBSYSNQN,
+                'host-nqn': self.HOSTNQN,
+            }
+        )
+
+    def tearDown(self):
+        pass
+
+    def _entry(self, **kwargs):
+        entry = {
+            'transport': 'tcp',
+            'traddr': '10.10.10.10',
+            'trsvcid': '4420',
+            'subsysnqn': self.SUBSYSNQN,
+            'params': {'tls': 'true', 'tls-key': self.PSK},
+        }
+        entry.update(kwargs)
+        return entry
+
+    def _config(self, *entries):
+        '''Make nvme.config_read() return @entries'''
+        return patch.object(ctrl.nvme, 'config_read', lambda ctx, file=None: list(entries))
+
+    def test_matching_entry(self):
+        entry = self._entry(
+            params={
+                'tls': 'yes',
+                'concat': 'off',
+                'keyring': '.nvme',
+                'tls-key': self.PSK,
+                'tls-key-identity': self.IDENTITY,
+                'ctrl-loss-tmo': '600',  # not a security parameter: ignored
+            }
+        )
+        with self._config(self._entry(traddr='1.1.1.1'), entry):
+            self.assertEqual(
+                ctrl.get_security_cfg(None, self.tid),
+                {
+                    'tls': True,
+                    'concat': False,
+                    'keyring': '.nvme',
+                    'tls_key': self.PSK,
+                    'tls_key_identity': self.IDENTITY,
+                },
+            )
+
+    def test_unspecified_parameters_match_anything(self):
+        # An entry that omits trsvcid and host-iface applies to any of them.
+        entry = self._entry()
+        del entry['trsvcid']
+        tid = trid.TID(
+            {
+                'transport': 'tcp',
+                'traddr': '10.10.10.10',
+                'trsvcid': '4420',
+                'subsysnqn': self.SUBSYSNQN,
+                'host-iface': 'wlp0s20f3',
+                'host-nqn': self.HOSTNQN,
+            }
+        )
+        with self._config(entry):
+            self.assertEqual(ctrl.get_security_cfg(None, tid), {'tls': True, 'tls_key': self.PSK})
+
+    def test_empty_value_resets_to_kernel_default(self):
+        with self._config(self._entry(params={'tls': 'true', 'keyring': ''})):
+            self.assertEqual(ctrl.get_security_cfg(None, self.tid), {'tls': True})
+
+    def test_no_matching_entry(self):
+        with self._config(self._entry(subsysnqn='nqn.1988-11.com.dell:SFSS:2:somethingelse')):
+            self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+        with self._config(self._entry(transport='rdma')):
+            self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+        with self._config(self._entry(host_iface='eth1')):
+            self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+        with self._config():
+            self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+    def test_unreadable_config_file(self):
+        def raise_oserror(ctx, file=None):
+            raise OSError('config_read failed: Invalid argument')
+
+        with patch.object(ctrl.nvme, 'config_read', raise_oserror):
+            with self.assertLogs(level='WARNING'):
+                self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+    def test_no_config_file_configured(self):
+        with patch.object(conf.SvcConf, 'nvme_config_file', property(lambda self: '')):
+            with self._config(self._entry()):
+                self.assertEqual(ctrl.get_security_cfg(None, self.tid), {})
+
+    def test_psk_in_keyring(self):
+        self.fs.create_file('/proc/keys', contents=self.KEYRING + self.KEY_REVOKED + self.KEY_LIVE)
+        self.assertTrue(ctrl._psk_in_keyring(self.HOSTNQN, self.SUBSYSNQN))
+        self.assertFalse(ctrl._psk_in_keyring(self.HOSTNQN, 'nqn.1988-11.com.dell:SFSS:2:somethingelse'))
+
+    def test_revoked_psk_does_not_count(self):
+        self.fs.create_file('/proc/keys', contents=self.KEYRING + self.KEY_REVOKED)
+        self.assertFalse(ctrl._psk_in_keyring(self.HOSTNQN, self.SUBSYSNQN))
+
+    def test_empty_keyring(self):
+        self.fs.create_file('/proc/keys', contents=self.KEYRING)
+        self.assertFalse(ctrl._psk_in_keyring(self.HOSTNQN, self.SUBSYSNQN))
+
+    def test_keys_not_readable(self):
+        with self.assertLogs(level='WARNING'):
+            self.assertFalse(ctrl._psk_in_keyring(self.HOSTNQN, self.SUBSYSNQN))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Lets `stafd`/`stacd` establish TLS-secured connections by taking the security
parameters from nvme-cli's connection configuration file,
[`nvme-fabrics.conf(5)`](https://github.com/linux-nvme/nvme-cli/blob/master/Documentation/nvme-fabrics.conf.txt).

`tls`, `concat`, `keyring`, `tls-key` and `tls-key-identity` have no equivalent
in `stafd.conf`/`stacd.conf`, and a TLS connection cannot be made without them.
libnvme3 exposes the file through `nvme.config_read()`, and its man page already
names nvme-stas as a consumer. For each controller we are about to connect to,
the matching entry's security parameters are applied; everything else in that
file stays ignored — connection parameters keep coming from `stafd.conf` /
`stacd.conf` as before. The file is configurable with the new `nvme-config-file`
option in `[Global]` (default `/etc/nvme/nvme-fabrics.conf`, empty to read none).

## Three things libnvme's API forced

1. **The keys are not part of the fabrics config.** `libnvmf_create_ctrl()`
   copies only `ctrl_params`, so `keyring`/`tls_key`/`tls_key_identity` passed in
   the `nvme.Ctrl()` dict are silently dropped — the argstr comes out as
   `…,ctrl_loss_tmo=600,tls` with no key and the connect fails with `ENOKEY`.
   They are set on the `nvme.Ctrl` object instead, the way stas already sets the
   KXCHAP keys. `tls` and `concat` are real fabrics-config fields and stay in the
   dict.

2. **Concurrent connects revoke each other's key.** libnvme imports the PSK on
   every connect that carries one, and `libnvmf_update_key()` revokes whatever
   key holds that identity before adding the replacement. Connects run in a
   thread pool (`gutil.AsyncTask`), so without serialization they fail with
   `EKEYREVOKED` ("Key has been revoked") or `ENOKEY`. Verified by disabling the
   lock on the test bed: 2 of 4 connections never came up. TLS connects are now
   serialized; non-TLS connects never touch the keyring and still run in
   parallel.

3. **Even serialized, re-importing breaks live controllers.** Each import
   revokes the key the already connected controllers were given; their next
   kernel-side reconnect then fails with
   `nvme nvmeN: queue 0: TLS handshake complete, error -5` and the controller
   sits in `connecting` forever. `/proc/keys` showed one revoked PSK per connect
   with a single survivor. The PSK is now handed to libnvme only while the
   keyring holds none for that (hostnqn, subsysnqn) — checked inside the connect
   lock, since the decision is only valid while no other connect can import.
   From then on libnvme and the kernel resolve the retained PSK by identity.

## Testing

Against an ONTAP array serving one subsystem over TLS 1.3 from two controllers
with two interfaces each (kernel 7.1.8, libnvme3 3.0-rc2):

- 4 connections, exactly **1** carried the PSK; the other three sent bare `tls`
  and the kernel resolved the key by identity. All four share the one live key
  serial, 0 connect failures.
- The discovery controllers connect in the clear (no entry in the file) — this
  array serves discovery unencrypted.
- `nvme reset` on two paths → TLS re-handshake succeeded, both stayed live. This
  is the case that failed before the fix in (3).
- Restarting `stacd` over live connections: 4 controllers borrowed, 0 new
  connects, 0 imports, key untouched.
- No PSK reaches the logs — it never enters the cfg dict `_do_connect()` prints.
- `meson test`: 121 ok, 0 fail, including 10 new unit tests for the lookup, the
  wildcard/reset semantics of the config file and the `/proc/keys` check.

## Also in this PR

- `nvme-config-file` documented in `stafd.conf(5)`/`stacd.conf(5)` and in both
  sample configuration files.

## Notes

- Requires libnvme3 >= 3.0 for `nvme.config_read()`, which is already the
  minimum in `meson.build`. Tested against 3.0-rc2.
- Points 1 and 3 above are really properties of the libnvme3 Python bindings.
  If the bindings grew an equivalent of `libnvmf_context_apply_params()`, or
  exposed the key helpers (`libnvmf_insert_tls_key_versioned()` /
  `libnvmf_lookup_key()`), the `/proc/keys` check here could be replaced by
  importing the PSK once and passing `tls_key_id`. Happy to rework it that way
  if you would rather add that to the bindings first.
