### PR TITLE
staslib: stop suppressing nvme-cli's udev rule

### DIFF
--- a/DISTROS.md
+++ b/DISTROS.md
@@ -142,15 +142,26 @@ These rules attempt to auto-connect I/O controllers on kernel events.
 ### The Race Condition
 
 - `nvme-cli` (via udev rules) and `nvme-stas` both react to the same NVMe events.
-- The udev rules in **nvme-cli ≤ 2.1.2** do **not** propagate the `host-iface` argument.
 - Because udev rules run in C and nvme-stas runs in Python, the udev rules typically win the race.
-- Result: connections may be established using the wrong TCP interface.
+- Historically, that meant `nvme connect-all` could connect controllers behind nvme-stas' back.
 
 ### Resolution
 
-nvme-stas **disables nvme-cli's udev rules** and assumes those responsibilities. It does that by installing a new udev rulefile, `/run/udev/rules.d/70-nvmf-autoconnect.rules`, which takes precedence over the file installed by the nvme-cli package.
-This ensures:
+libnvme's **ownership registry** settles the race at the source. Every controller
+nvme-stas connects is recorded as `owner=stas` in `/run/nvme/registry`, and
+`nvme connect-all` reads the Discovery Controller's owner before it does anything:
+when the controller belongs to somebody else, it skips the whole operation.
 
-- A single orchestrator handles connection events
-- Race conditions are eliminated
-- All NVMe/TCP connections consistently use the correct `host-iface`
+This means:
+
+- Each orchestrator owns the connections it makes, and no orchestrator disconnects
+  or takes over another's
+- nvme-stas and nvme-cli's udev rules coexist without racing
+- Hybrid configurations work as expected: controllers configured through nvme-cli
+  keep being handled by nvme-cli's udev rules, and those configured through
+  nvme-stas by nvme-stas
+
+Up to nvme-stas 2.x, the same problem was addressed by **disabling nvme-cli's udev
+rules** — nvme-stas installed `/run/udev/rules.d/70-nvmf-autoconnect.rules`, which
+took precedence over the file shipped by the nvme-cli package. That override is
+gone as of 3.0; nvme-cli's rules are left in place.

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -284,6 +284,7 @@ class Controller(stas.ControllerABC):
             return
 
         self._device = self._ctrl.name
+        stas.claim(self.tid, self._device)
         logging.info('%s | %s - Connection established!', self.id, self.device)
         self._connect_attempts = 0
         self._udev.register_for_device_events(self._device, self._on_udev_notification)

--- a/staslib/defs.py
+++ b/staslib/defs.py
@@ -10,7 +10,6 @@
 
 import os
 import sys
-import shutil
 import platform
 import libnvme3
 from staslib.version import KernelVersion
@@ -58,5 +57,3 @@ STACD_CONF_FILE = '@ETC@/stas/stacd.conf'
 
 NBFT_SYSFS_PATH = "/sys/firmware/acpi/tables"
 NBFT_SYSFS_FILENAME = "NBFT*"
-
-SYSTEMCTL = shutil.which('systemctl')

--- a/staslib/service.py
+++ b/staslib/service.py
@@ -12,7 +12,6 @@ which the Staf and the Stac objects are derived.'''
 import json
 import logging
 import pathlib
-import subprocess
 from itertools import filterfalse
 import dasbus.error
 import dasbus.client.observer
@@ -441,61 +440,28 @@ class Stac(Service):
 
 
 # ******************************************************************************
-# Only keep legacy FC rule (not even sure this is still in use today, but just to be safe).
-UDEV_RULE_OVERRIDE = r'''
-ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
-  ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
-  RUN+="%s --no-block restart nvmf-connect@--device\x3dnone\x09--transport\x3dfc\x09--traddr\x3d$env{NVMEFC_TRADDR}\x09--trsvcid\x3dnone\x09--host-traddr\x3d$env{NVMEFC_HOST_TRADDR}.service"
-'''
+def _remove_stale_udev_rule_override():
+    '''Remove the udev rule override that nvme-stas used to install.
 
+    Until 3.0, stafd shadowed nvme-cli's 70-nvmf-autoconnect.rules with a copy
+    in /run/udev/rules.d that kept only the legacy FC rule. udevd is written in
+    C and stafd in Python, so udevd always won the race to react to a Discovery
+    Log Page AEN, and "nvme connect-all" would connect controllers behind our
+    back. The ownership registry settles that race at the source: connect-all
+    reads the Discovery Controller's owner and does nothing at all when the
+    controller belongs to somebody else.
 
-def _udev_rule_ctrl(suppress):
-    '''Override the udev rule installed by nvme-cli
-    ('/usr/lib/udev/rules.d/70-nvmf-autoconnect.rules') by placing a copy in
-    /run/udev/rules.d, suppressing TCP I/O controller auto-connections by udevd
-    to avoid race conditions with stacd. When suppress is False, the override is
-    removed and nvme-cli's rule is restored. Configurable via "udev-rule" in
-    stacd.conf.
+    /run is a tmpfs, so a reboot disposes of the file on its own, but an
+    upgrade without a reboot does not, and the code that used to remove it is
+    gone. Drop it here instead. This can go once upgrades from 3.0 are a
+    distant memory.
     '''
-    udev_rule_file = pathlib.Path('/run/udev/rules.d', '70-nvmf-autoconnect.rules')
-    if suppress:
-        if not udev_rule_file.exists():
-            pathlib.Path('/run/udev/rules.d').mkdir(parents=True, exist_ok=True)
-            text = UDEV_RULE_OVERRIDE % (defs.SYSTEMCTL)
-            udev_rule_file.write_text(text)
-    else:
-        try:
-            udev_rule_file.unlink()
-        except FileNotFoundError:
-            pass
-
-
-def _is_dlp_changed_aen(udev_obj):
-    '''Check whether we received a Change of Discovery Log Page AEN'''
-    nvme_aen = udev_obj.get('NVME_AEN')
-    if not isinstance(nvme_aen, str):
-        return False
-
-    aen = int(nvme_aen, 16)
-    if aen != ctrl.DLP_CHANGED:
-        return False
-
-    logging.info(
-        '%s - Received AEN: Change of Discovery Log Page (%s)',
-        udev_obj.sys_name,
-        nvme_aen,
-    )
-    return True
-
-
-def _event_matches(udev_obj, nvme_events):
-    '''Return True if the udev object carries an NVMe Event matching one of the events in nvme_events.'''
-    nvme_event = udev_obj.get('NVME_EVENT')
-    if nvme_event not in nvme_events:
-        return False
-
-    logging.info('%s - Received "%s" event', udev_obj.sys_name, nvme_event)
-    return True
+    try:
+        pathlib.Path('/run/udev/rules.d', '70-nvmf-autoconnect.rules').unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as ex:
+        logging.warning('Unable to remove the stale udev rule override: %s', ex)
 
 
 # ******************************************************************************
@@ -532,8 +498,7 @@ class Staf(Service):
         # Create the D-Bus instance.
         self._config_dbus(dbus, defs.STAFD_DBUS_NAME, defs.STAFD_DBUS_PATH)
 
-        self._udev.register_for_action_events('change', self._nvme_cli_interop)
-        _udev_rule_ctrl(True)
+        _remove_stale_udev_rule_override()
 
     def info(self) -> dict:
         '''Return the status info for this object (used for debug).'''
@@ -543,12 +508,8 @@ class Staf(Service):
 
     def _release_resources(self):
         logging.debug('Staf._release_resources()')
-        if self._udev:
-            self._udev.unregister_for_action_events('change', self._nvme_cli_interop)
-
         super()._release_resources()
 
-        _udev_rule_ctrl(False)
         if self._avahi:
             self._avahi.kill()
             self._avahi = None
@@ -747,49 +708,3 @@ class Staf(Service):
         if self._alive() and self._cfg_soak_tmr is not None:
             logging.debug('Staf.referrals_changed()')
             self._cfg_soak_tmr.start()
-
-    def _nvme_cli_interop(self, udev_obj):
-        '''Interoperability with nvme-cli:
-        stafd will invoke nvme-cli's connect-all the same way nvme-cli's udev
-        rules would do normally. This is for the case where a user has an hybrid
-        configuration where some controllers are configured through nvme-stas
-        and others through nvme-cli. This is not an optimal configuration. It
-        would be better if everything was configured through nvme-stas, however
-        support for hybrid configuration was requested by users.'''
-
-        # Looking for 'change' events only
-        if udev_obj.action != 'change':
-            return
-
-        # Looking for events from Discovery Controllers only
-        if not udev.Udev.is_dc_device(udev_obj):
-            return
-
-        # Is the controller already being monitored by stafd?
-        for controller in self.get_controllers():
-            if controller.device == udev_obj.sys_name:
-                return
-
-        # Did we receive a Change of DLP AEN or an NVME Event indicating 'connect' or 'rediscover'?
-        if not _is_dlp_changed_aen(udev_obj) and not _event_matches(udev_obj, ('rediscover',)):
-            return
-
-        # We need to invoke "nvme connect-all" using nvme-cli's nvmf-connect@.service
-        # NOTE 1: Eventually, we'll be able to drop --host-traddr and --host-iface from
-        # the parameters passed to nvmf-connect@.service. A fix was added to connect-all
-        # to infer these two values from the device used to connect to the DC.
-        # Ref: https://github.com/linux-nvme/nvme-cli/pull/1812
-        #
-        # NOTE 2:--transport, --traddr, and --trsvcid, not needed when using --device
-        cnf = [
-            ('--device', udev_obj.sys_name),
-            ('--host-traddr', udev_obj.properties.get('NVME_HOST_TRADDR', None)),
-            ('--host-iface', udev_obj.properties.get('NVME_HOST_IFACE', None)),
-        ]
-        # Use systemd's escaped syntax (i.e. '=' is replaced by '\x3d', '\t' by '\x09', etc.
-        options = r'\x09'.join(
-            [rf'{option}\x3d{value}' for option, value in cnf if value not in (None, 'none', 'None', '')]
-        )
-        logging.debug('Invoking: systemctl restart nvmf-connect@%s.service', options)
-        cmd = [defs.SYSTEMCTL, '--quiet', '--no-block', 'restart', rf'nvmf-connect@{options}.service']
-        subprocess.run(cmd, check=False)

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -209,6 +209,38 @@ def _owner(device):
 
 
 # ******************************************************************************
+def claim(tid, device):
+    '''Record in libnvme's registry that this connection is ours.
+
+    libnvme registers owner=stas on the controllers it connects for us, but
+    Controller._do_connect() borrows an existing connection when it finds one
+    instead of making a new one, and a borrow never reaches libnvme's connect
+    path. Claiming it here is what tells everybody else we took it over:
+    "nvme connect-all" does nothing at all with a Discovery Controller that
+    somebody else owns, and that is what keeps udevd from racing us for it.
+
+    A connection that already belongs to somebody else is left alone.
+    remove_protected() should have kept it out of our hands long before we got
+    here, but ownership can change under a connection we already hold, and
+    taking it away from its owner is never ours to do.
+    '''
+    if not device or device == 'nvme?':
+        return
+
+    owner = _owner(device)
+    if owner is not None:
+        if owner != defs.REGISTRY_OWNER:
+            logging.debug('claim()                            - %s | %s: owned by "%s"', tid, device, owner)
+        return
+
+    try:
+        nvme.registry_update(conf.libnvme_ctx(), device, 'owner', defs.REGISTRY_OWNER)
+    except (OSError, ValueError) as ex:
+        # Not being able to claim it is not a reason to give up the connection.
+        logging.warning('Unable to claim the registry entry of %s: %s', device, ex)
+
+
+# ******************************************************************************
 def protected(tid, device=None):
     '''Return True if this controller must never be disconnected by us.
 

--- a/test/test-protection.py
+++ b/test/test-protection.py
@@ -124,6 +124,55 @@ class TestProtected(unittest.TestCase):
 
 
 # ==============================================================================
+class TestClaim(unittest.TestCase):
+    '''Unit tests for stas.claim(), which records that a connection is ours.
+    Controller._do_connect() borrows an existing connection instead of making a
+    new one, and a borrow never goes through libnvme's connect path, so nothing
+    would register us as the owner without this.'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.SANDBOX = libnvme_sandbox()
+
+    def _owner_of(self, device):
+        self.addCleanup(nvme.registry_delete, conf.libnvme_ctx(), device)
+        return nvme.registry_retrieve(conf.libnvme_ctx(), device, 'owner')
+
+    def _register(self, device, owner):
+        nvme.registry_update(conf.libnvme_ctx(), device, 'owner', owner)
+        self.addCleanup(nvme.registry_delete, conf.libnvme_ctx(), device)
+
+    def _make_tid(self):
+        return trid.TID({'transport': 'tcp', 'traddr': '1.1.1.1', 'subsysnqn': 'nqn.unrelated', 'hostnqn': HOSTNQN})
+
+    def test_unowned_connection_becomes_ours(self):
+        stas.claim(self._make_tid(), 'nvme20')
+        self.assertEqual(self._owner_of('nvme20'), defs.REGISTRY_OWNER)
+
+    def test_already_ours_stays_ours(self):
+        self._register('nvme21', defs.REGISTRY_OWNER)
+        stas.claim(self._make_tid(), 'nvme21')
+        self.assertEqual(nvme.registry_retrieve(conf.libnvme_ctx(), 'nvme21', 'owner'), defs.REGISTRY_OWNER)
+
+    def test_somebody_elses_connection_is_left_alone(self):
+        # remove_protected() should have kept this out of our hands, but
+        # ownership can change under a connection we already hold. Taking it
+        # away from its owner is never ours to do.
+        self._register('nvme22', 'discoverd')
+        stas.claim(self._make_tid(), 'nvme22')
+        self.assertEqual(nvme.registry_retrieve(conf.libnvme_ctx(), 'nvme22', 'owner'), 'discoverd')
+
+    def test_unconnected_controller(self):
+        # Controller.device is "nvme?" while there is no connection. libnvme
+        # rejects that as a device name, so we must not hand it over.
+        stas.claim(self._make_tid(), 'nvme?')
+        self.assertIsNone(stas._owner('nvme?'))
+
+    def test_no_device(self):
+        stas.claim(self._make_tid(), None)
+
+
+# ==============================================================================
 class TestRemoveProtected(unittest.TestCase):
     '''Unit tests for stas.remove_protected(), which keeps controllers that
     aren't ours out of the set stafd/stacd manage.'''

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import unittest
-from staslib import ctrl, log, service
+from staslib import log, service
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 
@@ -67,56 +67,6 @@ class Test(TestCase):
             None,
         )
         self.assertEqual(srv.remove_controller(controller=None, success=True), None)
-
-
-class FakeUdevObj:
-    sys_name = 'nvme0'
-
-    def __init__(self, nvme_aen=None, nvme_event=None):
-        self._aen = nvme_aen
-        self._event = nvme_event
-
-    def get(self, key):
-        if key == 'NVME_AEN':
-            return self._aen
-        if key == 'NVME_EVENT':
-            return self._event
-        return None
-
-
-class TestHelpers(unittest.TestCase):
-    '''Unit tests for module-level helper functions in service.py'''
-
-    def setUp(self):
-        log.init(syslog=False)
-
-    def test_is_dlp_changed_aen_no_aen(self):
-        self.assertFalse(service._is_dlp_changed_aen(FakeUdevObj()))
-
-    def test_is_dlp_changed_aen_not_string(self):
-        obj = FakeUdevObj()
-        obj._aen = 42  # integer, not string
-        self.assertFalse(service._is_dlp_changed_aen(obj))
-
-    def test_is_dlp_changed_aen_wrong_value(self):
-        # AEN present as string but wrong value → covers lines 535-537
-        self.assertFalse(service._is_dlp_changed_aen(FakeUdevObj(nvme_aen='0x000000')))
-
-    def test_is_dlp_changed_aen_true(self):
-        # AEN matches DLP_CHANGED → covers lines 539-544
-        self.assertTrue(service._is_dlp_changed_aen(FakeUdevObj(nvme_aen=hex(ctrl.DLP_CHANGED))))
-
-    def test_event_matches_no_event(self):
-        self.assertFalse(service._event_matches(FakeUdevObj(), ('connected',)))
-
-    def test_event_matches_not_in_list(self):
-        self.assertFalse(service._event_matches(FakeUdevObj(nvme_event='disconnect'), ('connected',)))
-
-    def test_event_matches_true(self):
-        # Event in list → covers lines 553-554
-        self.assertTrue(
-            service._event_matches(FakeUdevObj(nvme_event='connected'), ('connected', 'rediscover'))
-        )
 
 
 class FakeController:


### PR DESCRIPTION
stafd shadowed nvme-cli's 70-nvmf-autoconnect.rules with a copy in /run/udev/rules.d that kept only the legacy FC rule, because udevd (C) always won the race to react to a Discovery Log Page AEN and connected controllers behind stafd's back.

The ownership registry settles that race at the source: "nvme connect-all" reads the Discovery Controller's owner and does nothing at all when the controller belongs to somebody else. Drop the override, and with it _nvme_cli_interop(), which only existed to do by hand what the suppressed rule would have done for the controllers stafd was not monitoring.

That only holds if every connection we hold is registered as ours. libnvme records owner=stas on the controllers it connects, but _do_connect() borrows an existing connection when it finds one, and a borrow never reaches libnvme's connect path. stas.claim() fills that gap, and leaves a connection that already belongs to somebody else alone.

stafd also removes a stale override at startup: /run is a tmpfs so a reboot disposes of it, but an upgrade without a reboot does not.