### PR TITLE
staslib: make the singleton thread-safe and check its arguments

### DIFF
--- a/staslib/singleton.py
+++ b/staslib/singleton.py
@@ -8,24 +8,82 @@
 #
 '''Implementation of a singleton pattern'''
 
+import threading
+
 
 class Singleton(type):
-    '''metaclass implementation of a singleton pattern'''
+    '''metaclass implementation of a singleton pattern
 
+    Any caller may be the one that creates the instance; everybody else gets
+    the one that already exists. That is the point: code with no context of
+    its own can reach a singleton without some other component having had to
+    initialise a global first.
+
+    Callers that create the singleton pass its arguments, and callers that
+    only want to read it pass none. A caller that passes arguments once the
+    instance exists gets them checked against the ones it was created with:
+    the same arguments are fine (several components may each be prepared to be
+    the first one), different arguments are a bug and raise TypeError. Without
+    that check the arguments are silently dropped and the caller walks away
+    with an instance somebody else configured, which shows up much later in
+    whatever those arguments were supposed to configure.
+
+    Note the arguments are compared as they were passed, so Child('x') and
+    Child(value='x') count as different even though they call the same
+    constructor.
+    '''
+
+    # Maps a class to the (instance, args, kwargs) it was created with. The
+    # three live in one entry, written with a single assignment, so a caller
+    # on the lock-free path can never see an instance whose creation
+    # arguments have not been recorded yet, or one that a concurrent
+    # destroy() has half removed.
     _instances = {}
 
+    # One lock for every singleton class. Creation happens a handful of times
+    # per process, so contention is irrelevant, and a single lock cannot be
+    # taken out of order the way per-class locks could. It is reentrant
+    # because a singleton's __init__ is free to reach for another singleton;
+    # a plain Lock would deadlock the thread against itself.
+    _lock = threading.RLock()
+
     def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            # This variable declaration is required to force a
-            # strong reference on the instance.
-            instance = super(Singleton, cls).__call__(*args, **kwargs)
-            cls._instances[cls] = instance
-        return cls._instances[cls]
+        # Fast path: a singleton is created once and read from everywhere, so
+        # a caller that finds an instance never waits for the lock. Publishing
+        # the entry with one assignment is what makes this safe - whoever sees
+        # the entry sees a fully constructed object.
+        created = cls._instances.get(cls)
+
+        if created is None:
+            with cls._lock:
+                # Somebody may have created it while we waited for the lock.
+                created = cls._instances.get(cls)
+                if created is None:
+                    # This variable declaration is required to force a
+                    # strong reference on the instance.
+                    instance = super(Singleton, cls).__call__(*args, **kwargs)
+                    cls._instances[cls] = (instance, args, kwargs)
+                    return instance
+
+        instance, created_args, created_kwargs = created
+
+        if (args or kwargs) and (args, kwargs) != (created_args, created_kwargs):
+            raise TypeError(
+                '{name}() already exists and was created with different arguments; '
+                'the ones given here would be ignored. Use {name}() to get the '
+                'existing instance, or {name}.destroy() first to build a new '
+                'one.'.format(name=cls.__name__)
+            )
+
+        return instance
 
     def destroy(cls):
         '''Delete a singleton instance.
 
-        This is to be invoked using the derived class Name.
+        This is to be invoked using the derived class Name. It is meant for
+        unit tests: nothing in the daemons destroys a singleton, and doing so
+        while other threads are running is racy by nature, since they may
+        still hold a reference to the instance being dropped.
 
         For example:
 
@@ -45,4 +103,5 @@ class Singleton(type):
 
         print(f'{child1 is child2}') # False
         '''
-        cls._instances.pop(cls, None)
+        with cls._lock:
+            cls._instances.pop(cls, None)

--- a/test/meson.build
+++ b/test/meson.build
@@ -68,6 +68,7 @@ else
         ['Test NvmeOptions',   ['pyfakefs'], [srce_dir / 'test-nvme_options.py', ]],
         ['Test Protection',    [],           [srce_dir / 'test-protection.py',   ]],
         ['Test Service',       ['pyfakefs'], [srce_dir / 'test-service.py',      ]],
+        ['Test Singleton',     [],           [srce_dir / 'test-singleton.py',    ]],
         ['Test TID',           [],           [srce_dir / 'test-transport_id.py', ]],
         ['Test defs.py',       [],           [srce_dir / 'test-defs.py',         ]],
         ['Test Exclusions',    [],           [srce_dir / 'test-exclusions.py',   ]],

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -89,6 +89,8 @@ class StasProcessConfUnitTest(unittest.TestCase):
             ('I/O controller connection management', 'connect-attempts-on-ncc'): 0,
         }
 
+        conf.SvcConf.destroy()  # Make sure singleton does not exist
+        self.addCleanup(conf.SvcConf.destroy)
         service_conf = conf.SvcConf(default_conf=default_conf)
         service_conf.set_conf_file(StasProcessConfUnitTest.FNAME)
         self.assertEqual(service_conf.conf_file, StasProcessConfUnitTest.FNAME)
@@ -311,10 +313,20 @@ class TestParseController(unittest.TestCase):
 
 class TestSvcConfEdgeCases(unittest.TestCase):
     '''Edge-case tests for SvcConf validation: out-of-range values, invalid
-    sections/options.  These tests rely on the SvcConf singleton having been
-    initialised with a default_conf (which happens in StasProcessConfUnitTest),
-    so they are defined after that class.
+    sections/options.
+
+    SvcConf only validates sections and options when it was built with a
+    default_conf, so these tests build the singleton themselves. Inheriting
+    whichever instance happened to be created first is not good enough: any
+    module that calls SvcConf() with no arguments gets a singleton that
+    validates nothing, and every test here would then silently pass on a
+    config file that was never checked.
     '''
+
+    DEFAULT_CONF = {
+        ('Global', 'queue-size'): None,
+        ('Global', 'ip-family'): (4, 6),
+    }
 
     FNAME_OOR = '/tmp/stas-test-svc-oor.conf'
     FNAME_BADSEC = '/tmp/stas-test-svc-badsec.conf'
@@ -323,6 +335,9 @@ class TestSvcConfEdgeCases(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        conf.SvcConf.destroy()  # Make sure singleton does not exist
+        conf.SvcConf(default_conf=cls.DEFAULT_CONF)
+
         with open(cls.FNAME_OOR, 'w') as f:
             f.write('[Global]\nqueue-size=5\n')  # 5 is below the valid range [16, 1024]
         with open(cls.FNAME_BADSEC, 'w') as f:
@@ -334,6 +349,8 @@ class TestSvcConfEdgeCases(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        conf.SvcConf.destroy()  # Leave the next test file a clean slate
+
         for fname in (cls.FNAME_OOR, cls.FNAME_BADSEC, cls.FNAME_BADOPT, cls.FNAME_VALID):
             if os.path.exists(fname):
                 os.remove(fname)

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -191,6 +191,8 @@ class Test(TestCase):
         self.stafd_conf_file3 = '/etc/stas/stafd3.conf'
         self.fs.create_file(self.stafd_conf_file3, contents=stafd_conf_3)
 
+        conf.SvcConf.destroy()  # Make sure singleton does not exist
+        self.addCleanup(conf.SvcConf.destroy)
         self.svcconf = conf.SvcConf(default_conf=default_conf)
         self.svcconf.set_conf_file(self.stafd_conf_file1)
 

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import unittest
-from staslib import log, service
+from staslib import conf, log, service
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 
@@ -32,6 +32,11 @@ class Test(TestCase):
 
     def setUp(self):
         self.setUpPyfakefs()
+
+        # Service() builds the SvcConf singleton from its default_conf, which
+        # only works when we are the ones creating it.
+        conf.SvcConf.destroy()  # Make sure singleton does not exist
+        self.addCleanup(conf.SvcConf.destroy)
 
         os.environ['RUNTIME_DIRECTORY'] = "/run"
         self.fs.create_file(

--- a/test/test-singleton.py
+++ b/test/test-singleton.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python3
+import time
+import threading
+import unittest
+from staslib import singleton
+
+
+class Dummy(metaclass=singleton.Singleton):
+    '''Stand-in for the real singletons (SvcConf, SysConf, ...)'''
+
+    def __init__(self, value=None):
+        self.value = value
+
+
+class SlowDummy(metaclass=singleton.Singleton):
+    '''__init__ is slow on purpose, to widen the window for a race'''
+
+    instances_created = 0
+
+    def __init__(self, value=None):
+        time.sleep(0.05)
+        SlowDummy.instances_created += 1
+        self.value = value
+
+
+class Test(unittest.TestCase):
+    '''Unit tests for the Singleton metaclass'''
+
+    def setUp(self):
+        Dummy.destroy()  # Make sure singleton does not exist
+        self.addCleanup(Dummy.destroy)
+
+    def test_same_instance_is_returned(self):
+        self.assertIs(Dummy(), Dummy())
+
+    def test_first_call_takes_the_arguments(self):
+        self.assertEqual(Dummy('first').value, 'first')
+
+    def test_existing_instance_is_reachable_without_arguments(self):
+        Dummy('first')
+        self.assertEqual(Dummy().value, 'first')
+
+    def test_same_arguments_are_allowed(self):
+        # Several components may each be prepared to be the one that creates
+        # the singleton. Whoever gets there first wins, and the others are
+        # handed the instance they would have built themselves.
+        first = Dummy('same')
+        self.assertIs(Dummy('same'), first)
+        self.assertIs(Dummy(), first)
+
+    def test_same_keyword_arguments_are_allowed(self):
+        first = Dummy(value='same')
+        self.assertIs(Dummy(value='same'), first)
+
+    def test_different_arguments_are_refused(self):
+        # Dropping them silently hands the caller an instance somebody else
+        # configured. The symptom then shows up much later, in whatever the
+        # ignored arguments were supposed to configure.
+        Dummy('first')
+        with self.assertRaises(TypeError):
+            Dummy('second')
+        with self.assertRaises(TypeError):
+            Dummy(value='second')
+
+    def test_arguments_are_compared_as_passed(self):
+        # Positional and keyword forms of the same call are not equal. The
+        # check is deliberately literal rather than signature-aware.
+        Dummy('first')
+        with self.assertRaises(TypeError):
+            Dummy(value='first')
+
+    def test_arguments_are_refused_against_an_instance_created_without_any(self):
+        Dummy()
+        with self.assertRaises(TypeError):
+            Dummy('first')
+
+    def test_refusing_the_arguments_leaves_the_instance_alone(self):
+        first = Dummy('first')
+        with self.assertRaises(TypeError):
+            Dummy('second')
+        self.assertIs(Dummy(), first)
+        self.assertEqual(Dummy().value, 'first')
+
+    def test_destroy_allows_new_arguments(self):
+        Dummy('first')
+        Dummy.destroy()
+        self.assertEqual(Dummy('second').value, 'second')
+
+    def test_concurrent_creation_builds_exactly_one_instance(self):
+        '''Any thread may be the one that creates the singleton, but only one
+        of them may actually build it.'''
+        threads_count = 8
+
+        SlowDummy.destroy()
+        SlowDummy.instances_created = 0
+        self.addCleanup(SlowDummy.destroy)
+
+        barrier = threading.Barrier(threads_count)
+        results = []
+        results_lock = threading.Lock()
+
+        def create():
+            barrier.wait()  # Let every thread pile into __call__ at once
+            instance = SlowDummy('same')
+            with results_lock:
+                results.append(instance)
+
+        threads = [threading.Thread(target=create) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(SlowDummy.instances_created, 1)
+        self.assertEqual(len(results), threads_count)
+        self.assertEqual(len({id(instance) for instance in results}), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Singleton.__call__() tested for the instance, built it, and stored it as three separate steps, so two threads could both find nothing and both construct. One instance was then silently discarded and its __init__ side effects had already happened - NvmeOptions probing /dev/nvme-fabrics, SvcConf reading a config file, NbftConf parsing the ACPI tables. Worse, the thread that built the loser kept it, so SvcConf() is SvcConf() could be False across threads, which is the one guarantee the class exists to make. Eight threads racing the old code get eight different objects.

Publish the instance and the arguments it was created with as a single dict entry under a reentrant lock, with a lock-free read for the callers that only want the existing instance. The lock is reentrant because a singleton's __init__ may reach for another singleton, and shared by all of them because creation happens a handful of times per process.

Any caller may still be the one that creates the instance - that is what lets code with no context of its own reach a singleton without a global having been initialised first. But arguments given once the instance exists are now checked against the ones it was created with. Identical arguments are fine, since several components may each be prepared to be first. Different arguments were being dropped on the floor, handing the caller an instance somebody else configured, and now raise TypeError.

Four test call sites were relying on that silence, SvcConf being the one that matters: it only validates sections and options when built with a default_conf, so a bare conf.SvcConf() anywhere produces a singleton that validates nothing and every later
conf.SvcConf(default_conf=...) quietly returns it. test-config.py's edge cases only passed because meson runs each file in its own process; under a single pytest process, which is how the coverage job runs them, they failed. Let the tests that need a default_conf own the singleton instead of inheriting whichever one was created first.