### PR TITLE
staslib: drop two helpers left without callers

### DIFF
--- a/staslib/service.py
+++ b/staslib/service.py
@@ -93,13 +93,6 @@ class CtrlTerminator:
             if self._audit_tmr.time_remaining() == 0:
                 self._audit_tmr.start()
 
-    def pending_disposal(self, tid):
-        '''Return True if tid is pending disposal.'''
-        for _, _, _, controller_tid in self._controllers:
-            if controller_tid == tid:
-                return True
-        return False
-
     def info(self):
         '''Return info about this object (used for debug).'''
         info = {

--- a/staslib/udev.py
+++ b/staslib/udev.py
@@ -14,7 +14,7 @@ import logging
 from functools import partial
 import pyudev
 from gi.repository import GLib
-from staslib import defs, iputil, trid
+from staslib import defs, iputil
 
 
 # ******************************************************************************
@@ -429,20 +429,6 @@ class Udev:
             return attr_str[start:]
 
         return attr_str[start:end]
-
-    @staticmethod
-    def get_tid(device, ifaces):
-        '''Return the Transport ID (TID) associated with a udev device.'''
-        cid = Udev.get_cid(device)
-        if cid['transport'] == 'tcp':
-            src_addr = cid['src-addr']
-            if not cid['host-iface'] and src_addr:
-                # We'll try to find the interface from the source address on
-                # the connection. Only available if kernel exposes the source
-                # address (src_addr) in the "address" attribute.
-                cid['host-iface'] = iputil.get_interface(ifaces, iputil.get_ipaddress_obj(src_addr))
-
-        return trid.TID(cid)
 
     @staticmethod
     def get_cid(device):

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -100,25 +100,22 @@ class TestCtrlTerminator(unittest.TestCase):
         removed = []
         cb = lambda ctrl, ok: removed.append(ok)
 
-        # With empty list, pending_disposal always returns False
-        self.assertFalse(term.pending_disposal('fake-tid'))
+        # Nothing queued yet
+        self.assertNotIn('terminator.controller.fake-tid', term.info())
 
         term.dispose(fc, cb, keep_connection=False)
 
-        # pending_disposal — covers lines 87-88
-        self.assertTrue(term.pending_disposal('fake-tid'))
-        self.assertFalse(term.pending_disposal('other-tid'))
-
-        # info() — covers line 97
+        # fc has pending operations, so it lands in the garbage disposal
         info = term.info()
         self.assertIn('terminator.audit timer', info)
+        self.assertIn('terminator.controller.fake-tid', info)
 
         # _on_disposal_check() — covers lines 120-121
         # fc.all_ops_completed() returns False → controller stays pending
         result = term._on_disposal_check()
         from gi.repository import GLib
         self.assertEqual(result, GLib.SOURCE_CONTINUE)
-        self.assertTrue(term.pending_disposal('fake-tid'))
+        self.assertIn('terminator.controller.fake-tid', term.info())
 
         # kill() with non-empty _controllers — covers line 111
         term.kill()


### PR DESCRIPTION
Replacing disconnect-scope with honor-fabric-zoning removed stacd's audit of every connection on the system, and with it the last callers of two helpers that were only ever there to serve it:

  - Udev.get_tid(), which turned a udev device back into a TID so the audit could compare what the kernel had against what stacd wanted. Nothing references it any more, in the daemons or the tests, and dropping it leaves udev.py with no use for trid.

  - CtrlTerminator.pending_disposal(), which let the audit ask whether a controller was already on its way out. Only the unit test still called it; it now observes the disposal list through info(), which is what the daemons use.

stafd needs no equivalent cleanup. Its controllers only ever come from the configuration, Avahi or a referral, and _config_ctrls_finish() works out what to add and remove by comparing that set against the one it is already managing. It never enumerated the system's connections, so the registry did not make anything there redundant.