### PR TITLE
Hold discovery controller connections open only where EPCSD says to

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -287,7 +287,7 @@ reconnect-delay   = NaN
 
 [Discovery controller connection management]
 persistent-connections           = false
-zeroconf-connections-persistence = -1
+dc-giveup-timeout = infinity
 
 [Hello]
 hello = bye
@@ -404,7 +404,7 @@ tron = true
 
 [Discovery controller connection management]
 persistent-connections           = false
-zeroconf-connections-persistence = 0.5
+dc-giveup-timeout = 0.5
 
 [Service Discovery]
 zeroconf = enabled
@@ -443,7 +443,7 @@ pleo              = disabled
 
 [Discovery controller connection management]
 persistent-connections            = false
-zeroconf-connections-persistence  = 1:01
+dc-giveup-timeout  = 1:01
 
 [Controllers]
 exclude=transport=tcp;traddr=1.1.1.1
@@ -648,7 +648,7 @@ tron              = true
 
 [Discovery controller connection management]
 persistent-connections=false
-zeroconf-connections-persistence=0.5
+dc-giveup-timeout=0.5
 
 [Service Discovery]
 zeroconf=disabled
@@ -670,7 +670,7 @@ pleo=disabled
 
 [Discovery controller connection management]
 persistent-connections=false
-zeroconf-connections-persistence=0
+dc-giveup-timeout=0
 EOF
 log_file_contents 0 "${stafd_conf_fname}"
 printf "\n"

--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -286,7 +286,6 @@ queue-size        = 2000000
 reconnect-delay   = NaN
 
 [Discovery controller connection management]
-persistent-connections           = false
 dc-giveup-timeout = infinity
 
 [Hello]
@@ -329,6 +328,9 @@ cat > "${stas_conf_fname}" <<'EOF'
 hostsymname = coverage-host
 
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo  = 30
 queue-size      = 2000000
 ctrl-loss-tmo   = 10
@@ -403,7 +405,6 @@ cat > "${stafd_conf_fname}" <<'EOF'
 tron = true
 
 [Discovery controller connection management]
-persistent-connections           = false
 dc-giveup-timeout = 0.5
 
 [Service Discovery]
@@ -419,6 +420,9 @@ cat > "${stas_conf_fname}" <<'EOF'
 hostsymname = coverage-host
 
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo = 30
 
 [Discovery Controller]
@@ -442,7 +446,6 @@ ip-family         = ipv4
 pleo              = disabled
 
 [Discovery controller connection management]
-persistent-connections            = false
 dc-giveup-timeout  = 1:01
 
 [Controllers]
@@ -454,6 +457,9 @@ printf "\n"
 # Whitespace around the separators is deliberate - libnvme tolerates it.
 cat > "${stas_conf_fname}" <<'EOF'
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo  = 30
 queue-size      =
 reconnect-delay = 1
@@ -509,6 +515,9 @@ sleep 5
 log "Change connectivity configuration: a configured I/O subsystem"
 cat > "${stas_conf_fname}" <<'EOF'
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo = 30
 
 [I/O Controller Defaults]
@@ -647,7 +656,6 @@ cat > "${stafd_conf_fname}" <<'EOF'
 tron              = true
 
 [Discovery controller connection management]
-persistent-connections=false
 dc-giveup-timeout=0.5
 
 [Service Discovery]
@@ -669,7 +677,6 @@ ip-family=ipv6
 pleo=disabled
 
 [Discovery controller connection management]
-persistent-connections=false
 dc-giveup-timeout=0
 EOF
 log_file_contents 0 "${stafd_conf_fname}"
@@ -681,6 +688,9 @@ printf "\n"
 # separately, below, since one of them would sink the whole file.
 cat > "${stas_conf_fname}" <<'EOF'
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo  = 30
 queue-size      = 2000000
 reconnect-delay = 1
@@ -839,6 +849,9 @@ hostid      = aaaaaaaa-0000-0000-0000-000000000001
 hostsymname = persona-one
 
 [Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 keep-alive-tmo = 30
 
 [Discovery Controller]
@@ -854,11 +867,57 @@ reload_cfg "stafd"
 sleep 2
 
 #*******************************************************************************
-# A connectivity configuration that libnvme rejects outright. stafd must keep
-# the previous one running rather than tear down working connections.
-log "Change stafd config [7]: a connectivity configuration that must be rejected"
+# Let a discovery controller park. nvmet reports EPCSD=0, so under "auto" the
+# DC does not support a persistent connection: stafd disconnects it, keeps its
+# log pages, and comes back on the poll timer. One minute is the shortest
+# interval the option accepts, so this phase is deliberately slow.
+log "Change stafd config [7]: let a DC park, then come back"
+cat > "${stafd_conf_fname}" <<'EOF'
+[Global]
+tron                        = true
+
+[Discovery controller connection management]
+epcsd-poll-interval-minutes = 1
+EOF
+log_file_contents 0 "${stafd_conf_fname}"
+printf "\n"
+
 cat > "${stas_conf_fname}" <<'EOF'
 [Discovery Controller Defaults]
+persistent     = auto
+keep-alive-tmo = 30
+
+[Discovery Controller]
+controller = transport=tcp;traddr=localhost;trsvcid=8009
+EOF
+log_file_contents 0 "${stas_conf_fname}"
+printf "\n"
+
+reload_cfg "stafd"
+
+# The DC is created fresh by this config change, so it first spends up to
+# GET_SUPPORTED_MAX_ATTEMPTS * GET_SUPPORTED_RETRY_PERIOD_SEC seconds finding
+# out that nvmet does not implement Get Supported Log Pages, then fetches the
+# log page anyway. Only then is its persistence decided.
+sleep 30
+log "stafd should now have parked the DC (EPCSD=0)"
+run_cmd_coverage stafctl ls
+run_cmd_coverage stafctl status
+
+log "Waiting out the poll interval so the DC comes back"
+sleep 75
+run_cmd_coverage stafctl ls
+run_cmd_coverage stafctl status
+
+#*******************************************************************************
+# A connectivity configuration that libnvme rejects outright. stafd must keep
+# the previous one running rather than tear down working connections.
+log "Change stafd config [8]: a connectivity configuration that must be rejected"
+cat > "${stas_conf_fname}" <<'EOF'
+[Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
 queue-size = NaN
 
 [Discovery Controller]

--- a/doc/stafd.conf.xml
+++ b/doc/stafd.conf.xml
@@ -202,19 +202,42 @@
             </para>
 
             <varlistentry>
-                <term><varname>persistent-connections=</varname></term>
+                <term><varname>epcsd-poll-interval-minutes=</varname></term>
                 <listitem>
                     <para>
-                        Takes a boolean argument. Whether connections to
-                        Discovery Controllers (DC) are persistent. When
-                        true, connections initiated by stafd will persists
-                        even when stafd is stopped. When
-                        <parameter>false</parameter>, <code>stafd</code>
-                        will disconnect from all DCs it is connected to on
-                        exit.
+                        Takes an unsigned integer argument. How often to
+                        reconnect and re-check a Discovery Controller (DC)
+                        that does not support persistent discovery
+                        connections. Such a DC is disconnected between
+                        checks: there is nothing to hold open, and it cannot
+                        report that its discovery log pages changed, so
+                        polling is the only way to notice that they did.
                     </para>
                     <para>
-                        Defaults to <parameter>false</parameter>.
+                        A value of 0 is not valid. Unlike an interval that
+                        merely schedules extra work, this poll is the only
+                        way a disconnected DC comes back.
+                    </para>
+                    <para>
+                        Whether a DC's connection is held open at all is not
+                        configured here. That is the <varname>persistent</varname>
+                        key of
+                        <citerefentry>
+                            <refentrytitle>nvme-stas.conf</refentrytitle>
+                            <manvolnum>5</manvolnum>
+                        </citerefentry>,
+                        which takes <parameter>no</parameter>,
+                        <parameter>auto</parameter> or
+                        <parameter>force</parameter> and may be set for each
+                        DC. It defaults to <parameter>auto</parameter>: hold
+                        the connection open wherever the DC reports, through
+                        the EPCSD flag of its discovery log page entry, that
+                        it supports one. Note this default differs from that
+                        of the <code>nvme-cli</code> tools, which hold nothing
+                        open unless asked to.
+                    </para>
+                    <para>
+                        Defaults to <parameter>15</parameter>.
                     </para>
                 </listitem>
             </varlistentry>

--- a/doc/stafd.conf.xml
+++ b/doc/stafd.conf.xml
@@ -220,17 +220,19 @@
             </varlistentry>
 
             <varlistentry>
-                <term><varname>zeroconf-connections-persistence=</varname></term>
+                <term><varname>dc-giveup-timeout=</varname></term>
                 <listitem>
                     <para>
                         Takes a unit-less value in seconds, or a time span value
-                        such as "72hours" or "5days".  A value of 0 means no
-                        persistence. In other words, configuration acquired through
-                        zeroconf (mDNS service discovery) will be removed
-                        immediately when mDNS no longer reports the presence of
-                        a Discovery Controller (DC) and connectivity to that DC
-                        is lost. A value of -1 means that configuration acquired
-                        through zeroconf will persist forever.
+                        such as "72hours" or "5days". Note that the unit is
+                        seconds, so "72" means 72 seconds and not 72 hours.
+                        A value of 0 means no persistence. In other words,
+                        configuration acquired through zeroconf (mDNS service
+                        discovery) will be removed immediately when mDNS no
+                        longer reports the presence of a Discovery Controller
+                        (DC) and connectivity to that DC is lost. The value
+                        <literal>infinity</literal> means that configuration
+                        acquired through zeroconf will persist forever.
                     </para>
 
                     <para>

--- a/etc/nvme/stafd.conf
+++ b/etc/nvme/stafd.conf
@@ -66,14 +66,27 @@
 
 # ==============================================================================
 [Discovery controller connection management]
-# persistent-connections: Whether connections to Discovery Controllers (DC)
-#                         are persistent. If stafd is stopped, the connections
-#                         will persists. When this is set to false, stafd will
-#                         disconnect from all DCs it is connected to when stafd
-#                         is stopped.
-#                         Type:  boolean
-#                         Range: [false, true]
-#persistent-connections=true
+# epcsd-poll-interval-minutes: How often to reconnect and re-check a Discovery
+#                              Controller (DC) that does not support persistent
+#                              discovery connections. Such a DC is disconnected
+#                              between checks - there is nothing to hold open,
+#                              and it cannot tell us its log pages changed - so
+#                              polling is the only way to notice that they did.
+#
+#                              Whether a DC's connection is held open at all is
+#                              not configured here: it is the "persistent" key
+#                              of /etc/nvme/nvme-stas.conf, which takes "no",
+#                              "auto" or "force" and can be set per DC. The
+#                              default is "auto", meaning hold the connection
+#                              open wherever the DC reports (through EPCSD)
+#                              that it supports one. Note that this differs
+#                              from a plain "nvme connect-all", which does not
+#                              hold anything open unless asked to.
+#                              Type:  unsigned integer
+#                              Range: 1..N. 0 is not valid: this poll is the
+#                                     only way a parked DC comes back.
+#                              Default: 15
+#epcsd-poll-interval-minutes=15
 
 # dc-giveup-timeout: DCs that are discovered with mDNS service discovery
 #                    which are later lost (i.e. no mDNS and TCP connection

--- a/etc/nvme/stafd.conf
+++ b/etc/nvme/stafd.conf
@@ -75,19 +75,18 @@
 #                         Range: [false, true]
 #persistent-connections=true
 
-# zeroconf-connections-persistence: DCs that are discovered with mDNS service
-#                                   discovery which are later lost (i.e. no mDNS
-#                                   and TCP connection fails), will be purged from
-#                                   the configuration after this amount of time.
-#                                   Type:  Time specs.
-#                                   Unit:  Takes a unit-less value in seconds,
-#                                          or a time span (TS) value such as
-#                                          "3 days 5 hours".
-#                                   Range: -1, 0, TS.
-#                                          With "-1" equal to "no timeout" and
-#                                          0 equal to timeout immediately.
-#                                   Default: 72 hours (3 days)
-#zeroconf-connections-persistence=72hours
+# dc-giveup-timeout: DCs that are discovered with mDNS service discovery
+#                    which are later lost (i.e. no mDNS and TCP connection
+#                    fails), will be purged from the configuration after this
+#                    amount of time.
+#                    Type:  Time span.
+#                    Unit:  Takes a unit-less value in seconds, or a time span
+#                           such as "3 days 5 hours". Note the unit is seconds,
+#                           so "72" means 72 seconds, not 72 hours.
+#                    Range: "infinity", 0, or a time span. "infinity" means
+#                           never give up, 0 means give up immediately.
+#                    Default: 72 hours (3 days)
+#dc-giveup-timeout=72hours
 
 # ==============================================================================
 [Controllers]

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -481,6 +481,7 @@ class ConnConf(metaclass=singleton.Singleton):
         self._dc_defaults = dict()
         self._ioc_defaults = dict()
         self._host = dict()
+        self._loaded = False
         self.reload()
 
     @property
@@ -498,11 +499,13 @@ class ConnConf(metaclass=singleton.Singleton):
 
         A file that does not validate is rejected and the last known good
         configuration is left running: a fat-fingered edit must never tear down
-        working connections. An absent file is not an error - it simply
-        configures no controllers.
+        working connections. At startup there is no such configuration to keep,
+        and the daemon carries on with no controllers configured rather than
+        refusing to start - the file can be fixed and the daemon reloaded. An
+        absent file is not an error - it simply configures no controllers.
 
         Return True if the configuration was (re)loaded, False if the file was
-        rejected and the previous one kept.
+        rejected.
         '''
         ctx = libnvme_ctx()
         try:
@@ -511,15 +514,24 @@ class ConnConf(metaclass=singleton.Singleton):
             defaults = nvme.config_defaults(ctx, self._conf_file)
             host = nvme.config_host(ctx, self._conf_file)
         except (OSError, ValueError) as ex:
-            logging.error(
-                'File:%s - Invalid connectivity configuration, keeping the previous one: %s', self._conf_file, ex
-            )
+            if self._loaded:
+                logging.error(
+                    'File:%s - Invalid connectivity configuration, keeping the previous one: %s', self._conf_file, ex
+                )
+            else:
+                logging.error(
+                    'File:%s - Invalid connectivity configuration, no controllers will be configured '
+                    'until it is fixed and the configuration reloaded: %s',
+                    self._conf_file,
+                    ex,
+                )
             return False
 
         self._connections = connections
         self._dc_defaults = self._params(defaults.get('dc', {}))
         self._ioc_defaults = self._params(defaults.get('ioc', {}))
         self._host = host
+        self._loaded = True
         logging.debug('ConnConf.reload()                  - %s connection(s)', len(connections))
         return True
 

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -146,6 +146,24 @@ def _to_ncc(text):
     return value
 
 
+def _to_giveup_timeout(text):
+    """Convert a give-up timeout to a number of seconds.
+
+    "infinity" means never give up, and is carried as -1 because that is what
+    the rest of the code tests for. 0 means give up immediately. Anything
+    negative is rejected: "infinity" is how you spell forever.
+    """
+    value = _parse_single_val(text)
+    if value is not None and str(value).strip().lower() == 'infinity':
+        return -1
+
+    seconds = timeparse.timeparse(value)
+    if seconds is None or seconds < 0:
+        raise InvalidOption
+
+    return seconds
+
+
 def _to_ip_family(text):
     return tuple((4 if token == 'ipv4' else 6 for token in _parse_single_val(text).split('+')))
 
@@ -217,8 +235,8 @@ class SvcConf(metaclass=singleton.Singleton):
                 'default': True,
                 'txt-chk': lambda text: str(_parse_single_val(text)).lower() in ('false', 'true'),
             },
-            'zeroconf-connections-persistence': {
-                'convert': lambda text: timeparse.timeparse(_parse_single_val(text)),
+            'dc-giveup-timeout': {
+                'convert': _to_giveup_timeout,
                 'default': timeparse.timeparse('72hours'),
             },
         },
@@ -292,10 +310,8 @@ class SvcConf(metaclass=singleton.Singleton):
     ignore_iface = property(functools.partial(get_option, section='Global', option='ignore-iface'))
     pleo_enabled = property(functools.partial(get_option, section='Global', option='pleo'))
 
-    zeroconf_persistence_sec = property(
-        functools.partial(
-            get_option, section='Discovery controller connection management', option='zeroconf-connections-persistence'
-        )
+    dc_giveup_timeout_sec = property(
+        functools.partial(get_option, section='Discovery controller connection management', option='dc-giveup-timeout')
     )
 
     honor_fabric_zoning = property(

--- a/staslib/conf.py
+++ b/staslib/conf.py
@@ -164,6 +164,17 @@ def _to_giveup_timeout(text):
     return seconds
 
 
+def _to_poll_interval(text):
+    """Convert a poll interval in minutes. Unlike an interval that merely
+    schedules extra work, this one is the only way back for a parked
+    discovery controller, so 0 - "never" - is not a valid answer."""
+    value = _to_int(text)
+    if value <= 0:
+        raise InvalidOption
+
+    return value
+
+
 def _to_ip_family(text):
     return tuple((4 if token == 'ipv4' else 6 for token in _parse_single_val(text).split('+')))
 
@@ -230,10 +241,9 @@ class SvcConf(metaclass=singleton.Singleton):
             },
         },
         'Discovery controller connection management': {
-            'persistent-connections': {
-                'convert': _to_bool,
-                'default': True,
-                'txt-chk': lambda text: str(_parse_single_val(text)).lower() in ('false', 'true'),
+            'epcsd-poll-interval-minutes': {
+                'convert': _to_poll_interval,
+                'default': 15,
             },
             'dc-giveup-timeout': {
                 'convert': _to_giveup_timeout,
@@ -332,20 +342,11 @@ class SvcConf(metaclass=singleton.Singleton):
         return ['_nvme-disc._tcp', '_nvme-disc._udp'] if self.zeroconf_enabled else list()
 
     @property
-    def persistent_connections(self):
-        '''Return the "persistent-connections" config parameter.'''
+    def epcsd_poll_interval_sec(self):
+        '''Return how often to re-check a parked discovery controller, in
+        seconds. Configured in minutes, used as a timer value.'''
         section = 'Discovery controller connection management'
-        option = 'persistent-connections'
-
-        # Use ignore_default=True so we can distinguish "not set in file" from
-        # "set to false". The per-daemon default (stafd vs stacd) differs and is
-        # held in self._defaults rather than in OPTION_CHECKER, so we fall back
-        # to that dict explicitly.
-        value = self.get_option(section, option, ignore_default=True)
-        if value is not None:
-            return value
-
-        return self._defaults.get((section, option), True)
+        return 60 * self.get_option(section, 'epcsd-poll-interval-minutes')
 
     def get_excluded(self):
         '''Return the list of excluded controllers. This is the union of the

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -72,6 +72,22 @@ def get_ncc(eflags: int):
     return eflags & nvme.NVMF_DISC_EFLAGS_NCC != 0
 
 
+# Discovery Log Page Entry subtypes, spelled the way libnvme spells them
+# (libnvmf_subtype_str()). They read as the spec describes them rather than as
+# the enum names suggest, which is the point: NVME_NQN_DISC is a referral to
+# *another* discovery service, while NVME_NQN_CURR is the entry describing the
+# controller that served the log page.
+SUBTYPE_REFERRAL = 'discovery subsystem referral'  # NVME_NQN_DISC
+SUBTYPE_IOC = 'nvme subsystem'  # NVME_NQN_NVME
+SUBTYPE_SELF = 'current discovery subsystem'  # NVME_NQN_CURR
+
+
+def get_epcsd(eflags: int):
+    """Return True if the Explicit Persistent Connection Support for Discovery
+    (EPCSD) bit is set in eflags."""
+    return eflags & nvme.NVMF_DISC_EFLAGS_EPCSD != 0
+
+
 def dlp_supp_opts_as_string(dlp_supp_opts: int):
     '''Return a list of human-readable option names supported by the
     Get Discovery Log Page command.'''
@@ -136,6 +152,12 @@ class Controller(stas.ControllerABC):
     def connected(self):
         '''Return True if a connection to the controller is currently established.'''
         return self._ctrl and self._ctrl.connected
+
+    def parked(self):
+        '''Return True if this controller is disconnected on purpose. Only a
+        discovery controller can be, so this is the answer for every other
+        kind.'''
+        return False
 
     def controller_id_dict(self) -> dict:
         '''Return the controller ID as a dict.'''
@@ -214,6 +236,11 @@ class Controller(stas.ControllerABC):
         self._ctrl = None
         self._device = None
         self._connect_attempts = 0
+        if self.parked():
+            # We disconnected this controller on purpose. The poll timer, not
+            # the retry timer, is what brings it back.
+            return
+
         # Reset the retry interval to fast since this is effectively a fresh start
         self._retry_connect_tmr.start(self.FAST_CONNECT_RETRY_PERIOD_SEC)
 
@@ -407,7 +434,6 @@ class Dc(Controller):
 
     GET_LOG_PAGE_RETRY_PERIOD_SEC = 20
     REGISTRATION_RETRY_PERIOD_SEC = 5
-    GET_SUPPORTED_RETRY_PERIOD_SEC = 5
 
     def __init__(self, staf, tid: trid.TID, log_pages=None, origin=None):
         super().__init__(tid, staf, discovery_ctrl=True)
@@ -425,6 +451,14 @@ class Dc(Controller):
         self._ctrl_unresponsive_time = None  # The time at which connectivity was lost
         self._ctrl_unresponsive_tmr = gutil.GTimer(0, self._serv.controller_unresponsive, self.tid)
 
+        # A DC that does not support persistent discovery connections is
+        # "parked": disconnected, but still tracked, with a timer to reconnect
+        # and re-read its log pages. There is nothing to hold open, and no AEN
+        # will arrive to tell us the log pages changed, so polling is the only
+        # way to notice.
+        self._parked = False
+        self._epcsd_poll_tmr = gutil.GTimer(0, self._on_epcsd_poll_expired)
+
     def _release_resources(self):
         logging.debug('Dc._release_resources()            - %s | %s', self.id, self.device)
         super()._release_resources()
@@ -432,8 +466,12 @@ class Dc(Controller):
         if self._ctrl_unresponsive_tmr is not None:
             self._ctrl_unresponsive_tmr.kill()
 
+        if self._epcsd_poll_tmr is not None:
+            self._epcsd_poll_tmr.kill()
+
         self._log_pages = list()
         self._ctrl_unresponsive_tmr = None
+        self._epcsd_poll_tmr = None
 
     def _kill_ops(self):
         super()._kill_ops()
@@ -475,6 +513,10 @@ class Dc(Controller):
         '''Called when a SIGHUP/reload signal is received.'''
         logging.debug('Dc.reload_hdlr()                   - %s | %s', self.id, self.device)
 
+        # "persistent" may have changed. Re-decide now rather than waiting for
+        # the next log page retrieval, which for a connected and quiet
+        # controller may never come.
+        self._apply_persistence_policy()
         self._handle_lost_controller()
         self._resync_with_controller()
 
@@ -486,6 +528,9 @@ class Dc(Controller):
         )
         info = super().info()
         info['origin'] = self.origin
+        info['persistent'] = self.persistence_mode()
+        info['epcsd'] = str(self.epcsd())
+        info['parked'] = str(self._parked)
         if self.origin == 'discovered':
             # The code that handles "unresponsive" DCs only applies to
             # discovered DCs. So, let's only print that info when it's relevant.
@@ -516,16 +561,135 @@ class Dc(Controller):
 
     def referrals(self) -> list:
         '''Return the list of referral entries from the cached log pages.'''
-        return [page for page in self._log_pages if page['subtype'] == 'referral']
+        return [page for page in self._log_pages if page['subtype'] == SUBTYPE_REFERRAL]
+
+    # --------------------------------------------------------------------------
+    # Persistent discovery connections (EPCSD, TP8010)
+
+    def persistence_mode(self):
+        """Return "no", "auto" or "force" for this discovery controller.
+
+        The mode comes from the connectivity configuration: this DC's own
+        "persistent" key when it has one, else the defaults for discovery
+        controllers. Note the default differs from libnvme's, whose unset
+        value behaves as "no": stafd exists to hold discovery connections
+        open so that it is told when log pages change, so tearing them down
+        by default would defeat the daemon. nvme-discoverd makes the same
+        choice.
+        """
+        mode = self.tid.cfg.get('persistent', conf.ConnConf().defaults(True).get('persistent'))
+        return mode if mode in ('no', 'auto', 'force') else 'auto'
+
+    def _self_entry(self):
+        """Return this controller's own entry in its log pages, if it published
+        one. That entry describes the DC we are already connected to, which is
+        why it is exempt from the address filtering."""
+        for page in self._log_pages:
+            if page.get('subtype') == SUBTYPE_SELF:
+                return page
+
+        return None
+
+    def epcsd(self):
+        """Return True if this DC supports persistent discovery connections.
+
+        Its own entry decides. Failing that, what the DC that referred us to
+        it said about it - a referral entry carries the referred-to DC's
+        EPCSD. Failing both, assume it does not, which is what libnvme's
+        dc_decide() and nvme-discoverd both do.
+        """
+        self_entry = self._self_entry()
+        if self_entry is not None:
+            return get_epcsd(get_eflags(self_entry))
+
+        eflags = self._serv.referral_eflags(self.tid)
+        return get_epcsd(eflags) if eflags is not None else False
+
+    def _apply_persistence_policy(self):
+        """Decide whether to hold this DC's connection open, and park it if
+        not. Called after every log page retrieval, which is the only point
+        at which the answer can change."""
+        mode = self.persistence_mode()
+        if mode == 'force' or (mode == 'auto' and self.epcsd()):
+            self._unpark()
+        else:
+            self._park(mode)
+
+    def _park(self, mode):
+        """Disconnect, but keep tracking. The log pages stay cached - stacd is
+        still entitled to the controllers this DC reported - and a timer
+        brings us back to re-read them."""
+        if self._parked:
+            return
+
+        self._parked = True
+        interval = conf.SvcConf().epcsd_poll_interval_sec
+        logging.info(
+            '%s | %s - persistent=%s%s, disconnecting; re-checking in %s sec',
+            self.id,
+            self.device,
+            mode,
+            ' and EPCSD=0' if mode == 'auto' else '',
+            interval,
+        )
+        self._epcsd_poll_tmr.start(interval)
+        self.disconnect(self._on_parked, False)
+
+    def _on_parked(self, _controller, success):
+        """Disconnect completed. Nothing to do but say so: unlike every other
+        disconnect in the daemon, this one does not dispose of the object."""
+        logging.debug('Dc._on_parked()                    - %s | %s: success=%s', self.id, self.device, success)
+
+    def _unpark(self):
+        """This DC supports a persistent connection after all, so stop polling
+        and let the ordinary connect path hold it open."""
+        if not self._parked:
+            return
+
+        logging.info('%s | %s - persistent discovery connection supported, resuming', self.id, self.device)
+        self._parked = False
+        self._epcsd_poll_tmr.stop()
+
+    def _on_epcsd_poll_expired(self):
+        """Time to look again: reconnect and re-read the log pages, since a
+        parked DC cannot tell us they changed."""
+        logging.info('%s | %s - Poll interval expired, re-checking', self.id, self.device)
+        self._parked = False
+        if not self.connected():
+            self._connect_attempts = 0
+            self._try_to_connect_deferred.schedule()
+
+        return GLib.SOURCE_REMOVE
+
+    def parked(self):
+        """Return True if this DC is parked: deliberately disconnected because
+        it does not support a persistent discovery connection."""
+        return self._parked
+
+    # A Direct Discovery controller, as sysfs reports it. "ddc" is what a
+    # controller implementing TP8010 says; "none" is what everything older
+    # says, because DCTYPE was carved out of a previously unused field that
+    # defaults to 0 ("Discovery controller type is not reported"), so every
+    # DC predating the CDC reads as "none". A CDC is required to report
+    # "cdc", so excluding that one value happens to give the right answer
+    # today. Name the two we mean anyway: a third type of discovery
+    # controller would otherwise be taken for a DDC by a test that only ever
+    # knew how to rule out CDCs.
+    DDC_DCTYPES = ('none', 'ddc')
 
     def _is_ddc(self):
-        return self._ctrl and self._ctrl.dctype != 'cdc'
+        return self._ctrl is not None and self._ctrl.dctype in Dc.DDC_DCTYPES
 
     def _on_aen(self, aen: int):
         if aen == DLP_CHANGED and self._get_log_op:
             self._get_log_op.run_async()
 
     def _handle_lost_controller(self):
+        if self._parked:
+            # Disconnected because it does not support a persistent connection,
+            # not because we lost it.
+            return
+
         if self.origin == 'discovered':  # Only apply to mDNS-discovered DCs
             if not self._serv.is_avahi_reported(self.tid) and not self.connected():
                 timeout = conf.SvcConf().dc_giveup_timeout_sec
@@ -584,6 +748,12 @@ class Dc(Controller):
         return self._udev.find_nvme_dc_device(self.tid)
 
     def _post_registration_actions(self):
+        # PLEOS - whether this controller can return port-local entries only -
+        # is reported in the Supported Log Pages log page, so learning it costs
+        # a second Get Log Page. Only ask when the answer could change what we
+        # do: the spec says to ignore PLEOS on anything but a DDC, and only a
+        # DDC may support the feature, so a CDC is never worth asking; and if
+        # PLEO is disabled we would not set it whatever the answer.
         if conf.SvcConf().pleo_enabled and self._is_ddc():
             self._get_supported_op = gutil.AsyncTask(
                 self._on_get_supported_success, self._on_get_supported_fail, self._ctrl.get_supported_log_pages
@@ -706,21 +876,30 @@ class Dc(Controller):
             op_obj.kill()
             return
 
-        logging.debug(
-            'Dc._on_get_supported_fail()        - %s | %s: %s. Retry in %s sec',
+        # No retry. A controller that answers "unrecognized" will not start
+        # recognising it, and PLEOS is only ever consulted to decide whether
+        # to set PLEO. So assume PLEOS=0 - do not set PLEO - and go get the
+        # log pages, which is the point of all this. That is exactly what we
+        # would do for a DDC that answered and reported no PLEO support.
+        #
+        # Retrying instead used to mean never retrieving the log pages at
+        # all: stacd would learn of no I/O controllers, and the only clue was
+        # a single throttled error line.
+        #
+        # The cost is that a DDC which does support PLEO returns entries that
+        # may not be reachable through the port we asked on. Same as
+        # configuring pleo=disabled, so not a new exposure.
+        logging.error(
+            '%s | %s - Failed to Get supported log pages from Discovery Controller. %s. '
+            'Assuming PLEOS=0 and retrieving the discovery log page without PLEO.',
             self.id,
             self.device,
             err,
-            Dc.GET_SUPPORTED_RETRY_PERIOD_SEC,
         )
-        if fail_cnt == 1:  # Throttle the logs. Only print the first time the command fails
-            logging.error(
-                '%s | %s - Failed to Get supported log pages from Discovery Controller. %s',
-                self.id,
-                self.device,
-                err,
-            )
-        op_obj.retry(Dc.GET_SUPPORTED_RETRY_PERIOD_SEC)
+        op_obj.kill()
+        self._get_supported_op = None
+        self._get_log_op = gutil.AsyncTask(self._on_get_log_success, self._on_get_log_fail, self._ctrl.discover)
+        self._get_log_op.run_async()
 
     # --------------------------------------------------------------------------
     def _on_get_log_success(self, op_obj: gutil.AsyncTask, data):
@@ -734,12 +913,20 @@ class Dc(Controller):
         # Note that for historical reasons too long to explain, the CDC may
         # return invalid addresses ('0.0.0.0', '::', or ''). Those need to
         # be filtered out.
+        #
+        # The exception is this controller's own entry (NVME_NQN_CURR): it
+        # is not something to connect to, it describes the controller we are
+        # already talking to, and its EFLAGS carry that controller's EPCSD.
+        # An address we would never dial is no reason to discard it. Nothing
+        # connects it either way - referrals() takes only "referral" entries
+        # and stacd only "nvme" ones.
         referrals_before = self.referrals()
         self._log_pages = (
             [
                 {k.strip(): str(v).strip() for k, v in dictionary.items()}
                 for dictionary in data
-                if dictionary.get('traddr', '').strip() not in ('0.0.0.0', '::', '')
+                if dictionary.get('subtype') == SUBTYPE_SELF
+                or dictionary.get('traddr', '').strip() not in ('0.0.0.0', '::', '')
             ]
             if data
             else list()
@@ -748,6 +935,7 @@ class Dc(Controller):
             '%s | %s - Received discovery log pages (num records=%s).', self.id, self.device, len(self._log_pages)
         )
         referrals_after = self.referrals()
+        self._apply_persistence_policy()
         self._serv.log_pages_changed(self, self.device)
         if referrals_after != referrals_before:
             logging.debug(

--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -459,7 +459,7 @@ class Dc(Controller):
     @property
     def origin(self):
         '''Return how this controller was discovered: "discovered" (mDNS/TP8009),
-        "configured" (stafd.conf), or "referral".'''
+        "configured" (nvme-stas.conf), or "referral".'''
         return self._origin
 
     @origin.setter
@@ -480,7 +480,7 @@ class Dc(Controller):
 
     def info(self) -> dict:
         '''Return status info for this discovery controller.'''
-        timeout = conf.SvcConf().zeroconf_persistence_sec
+        timeout = conf.SvcConf().dc_giveup_timeout_sec
         unresponsive_time = (
             time.asctime(self._ctrl_unresponsive_time) if self._ctrl_unresponsive_time is not None else '---'
         )
@@ -528,7 +528,7 @@ class Dc(Controller):
     def _handle_lost_controller(self):
         if self.origin == 'discovered':  # Only apply to mDNS-discovered DCs
             if not self._serv.is_avahi_reported(self.tid) and not self.connected():
-                timeout = conf.SvcConf().zeroconf_persistence_sec
+                timeout = conf.SvcConf().dc_giveup_timeout_sec
                 if timeout >= 0:
                     if self._ctrl_unresponsive_time is None:
                         self._ctrl_unresponsive_time = time.localtime()

--- a/staslib/service.py
+++ b/staslib/service.py
@@ -459,9 +459,7 @@ class Staf(Service):
         default_conf = {
             ('Global', 'tron'): False,
             ('Discovery controller connection management', 'persistent-connections'): True,
-            ('Discovery controller connection management', 'zeroconf-connections-persistence'): timeparse.timeparse(
-                '72hours'
-            ),
+            ('Discovery controller connection management', 'dc-giveup-timeout'): timeparse.timeparse('72hours'),
             ('Global', 'ignore-iface'): False,
             ('Global', 'ip-family'): (4, 6),
             ('Global', 'pleo'): True,

--- a/staslib/service.py
+++ b/staslib/service.py
@@ -208,21 +208,24 @@ class Service(stas.ServiceABC):
 class Stac(Service):
     '''STorage Appliance Connector (STAC)'''
 
+    # The options stacd accepts, with their defaults. SvcConf builds its
+    # valid-option set from this, so an option missing here is rejected as
+    # invalid however well OPTION_CHECKER knows it.
+    DEFAULT_CONF = {
+        ('Global', 'tron'): False,
+        ('Global', 'ignore-iface'): False,
+        ('Global', 'ip-family'): (4, 6),
+        ('Controllers', 'exclude'): list(),
+        ('I/O controller connection management', 'honor-fabric-zoning'): True,
+        ('I/O controller connection management', 'connect-attempts-on-ncc'): 0,
+    }
+
     CONFIGURES_DCS = False
 
     CONF_STABILITY_LONG_SOAK_TIME_SEC = 10
 
     def __init__(self, args, dbus):
-        default_conf = {
-            ('Global', 'tron'): False,
-            ('Global', 'ignore-iface'): False,
-            ('Global', 'ip-family'): (4, 6),
-            ('Controllers', 'exclude'): list(),
-            ('I/O controller connection management', 'honor-fabric-zoning'): True,
-            ('I/O controller connection management', 'connect-attempts-on-ncc'): 0,
-        }
-
-        super().__init__(args, default_conf, self._reload_hdlr)
+        super().__init__(args, Stac.DEFAULT_CONF, self._reload_hdlr)
 
         # Create the D-Bus instance.
         self._config_dbus(dbus, defs.STACD_DBUS_NAME, defs.STACD_DBUS_PATH)
@@ -319,7 +322,7 @@ class Stac(Service):
             host_iface = staf_data['discovery-controller']['host-iface']
             hostnqn = staf_data['discovery-controller']['hostnqn']
             for dlpe in staf_data['log-pages']:
-                if dlpe.get('subtype') == 'nvme':  # eliminate discovery controllers
+                if dlpe.get('subtype') == ctrl.SUBTYPE_IOC:  # eliminate discovery controllers
                     tid = stas.tid_from_dlpe(dlpe, host_traddr, host_iface, hostnqn)
                     discovered_ctrls[tid] = dlpe
 
@@ -453,21 +456,24 @@ def _remove_stale_udev_rule_override():
 class Staf(Service):
     '''STorage Appliance Finder (STAF)'''
 
+    # The options stafd accepts, with their defaults. SvcConf builds its
+    # valid-option set from this, so an option missing here is rejected as
+    # invalid however well OPTION_CHECKER knows it.
+    DEFAULT_CONF = {
+        ('Global', 'tron'): False,
+        ('Global', 'ignore-iface'): False,
+        ('Global', 'ip-family'): (4, 6),
+        ('Global', 'pleo'): True,
+        ('Service Discovery', 'zeroconf'): True,
+        ('Controllers', 'exclude'): list(),
+        ('Discovery controller connection management', 'dc-giveup-timeout'): timeparse.timeparse('72hours'),
+        ('Discovery controller connection management', 'epcsd-poll-interval-minutes'): 15,
+    }
+
     CONFIGURES_DCS = True
 
     def __init__(self, args, dbus):
-        default_conf = {
-            ('Global', 'tron'): False,
-            ('Discovery controller connection management', 'persistent-connections'): True,
-            ('Discovery controller connection management', 'dc-giveup-timeout'): timeparse.timeparse('72hours'),
-            ('Global', 'ignore-iface'): False,
-            ('Global', 'ip-family'): (4, 6),
-            ('Global', 'pleo'): True,
-            ('Service Discovery', 'zeroconf'): True,
-            ('Controllers', 'exclude'): list(),
-        }
-
-        super().__init__(args, default_conf, self._reload_hdlr)
+        super().__init__(args, Staf.DEFAULT_CONF, self._reload_hdlr)
 
         self._avahi = avahi.Avahi(self._sysbus, self._avahi_change)
         self._avahi.config_stypes(conf.SvcConf().stypes)
@@ -517,8 +523,13 @@ class Staf(Service):
         return controllers
 
     def _keep_connections_on_exit(self):
-        '''Return True if connections should persist when stafd exits.'''
-        return conf.SvcConf().persistent_connections
+        '''Return True if connections should persist when stafd exits.
+
+        A connection we hold open is one worth keeping; a parked DC has none
+        to keep. "no" says not to hold discovery connections at all, so on the
+        way out there is nothing to leave behind.
+        '''
+        return any(not dc.parked() for dc in self.get_controllers())
 
     def _reload_hdlr(self):
         '''Reload the configuration file. Triggered by SIGHUP (systemctl reload stafd).'''
@@ -575,6 +586,27 @@ class Staf(Service):
             for controller in self.get_controllers()
             for dlpe in controller.referrals()
         ]
+
+    def referral_eflags(self, tid):
+        '''Return the EFLAGS a discovery controller published for @tid in the
+        referral entry that led us to it, or None if no DC refers to it.
+
+        A DC that publishes no entry of its own leaves its parent's referral
+        entry as the only statement about whether it supports a persistent
+        connection.
+        '''
+        for controller in self.get_controllers():
+            for dlpe in controller.referrals():
+                referred = stas.tid_from_dlpe(
+                    dlpe,
+                    controller.tid.host_traddr,
+                    controller.tid.host_iface,
+                    controller.tid.hostnqn,
+                )
+                if referred == tid:
+                    return ctrl.get_eflags(dlpe)
+
+        return None
 
     def _config_ctrls_finish(self, configured_ctrl_list: list):
         '''Finish discovery controller configuration after hostname resolution.

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -67,7 +67,6 @@ class StasProcessConfUnitTest(unittest.TestCase):
             ('Global', 'tron'): False,
             ('Global', 'ignore-iface'): False,
             ('Global', 'ip-family'): (4, 6),
-            ('Discovery controller connection management', 'persistent-connections'): True,
             ('Global', 'pleo'): True,
             ('Service Discovery', 'zeroconf'): True,
             ('Controllers', 'controller'): list(),
@@ -83,7 +82,6 @@ class StasProcessConfUnitTest(unittest.TestCase):
         self.assertEqual(service_conf.conf_file, StasProcessConfUnitTest.FNAME)
         self.assertTrue(service_conf.tron)
         self.assertTrue(getattr(service_conf, 'tron'))
-        self.assertTrue(service_conf.persistent_connections)
         self.assertTrue(service_conf.pleo_enabled)
         self.assertEqual(service_conf.honor_fabric_zoning, True)
         self.assertFalse(service_conf.ignore_iface)
@@ -203,6 +201,54 @@ class TestDcGiveupTimeout(unittest.TestCase):
         cnf = self._load('not-a-timespan')
         with self.assertLogs(level='WARNING'):
             self.assertEqual(cnf.dc_giveup_timeout_sec, 72 * 60 * 60)
+
+
+class TestEpcsdPollInterval(unittest.TestCase):
+    '''Unit tests for epcsd-poll-interval-minutes'''
+
+    SECTION = 'Discovery controller connection management'
+
+    def setUp(self):
+        fd, self.fname = tempfile.mkstemp(prefix='stas-poll-', suffix='.conf')
+        os.close(fd)
+        self.addCleanup(os.remove, self.fname)
+        conf.SvcConf.destroy()
+        self.addCleanup(conf.SvcConf.destroy)
+
+    def _load(self, value):
+        with open(self.fname, 'w') as f:
+            f.write('[%s]\nepcsd-poll-interval-minutes=%s\n' % (TestEpcsdPollInterval.SECTION, value))
+        cnf = conf.SvcConf()
+        cnf.set_conf_file(self.fname)
+        return cnf
+
+    def test_minutes_are_returned_as_seconds(self):
+        self.assertEqual(self._load('15').epcsd_poll_interval_sec, 900)
+        self.assertEqual(self._load('1').epcsd_poll_interval_sec, 60)
+
+    def test_zero_is_rejected(self):
+        '''This poll is the only way a parked controller comes back, so
+        "never" is not a valid answer.'''
+        cnf = self._load('0')
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.epcsd_poll_interval_sec, 900)  # the default
+
+    def test_a_negative_value_is_rejected(self):
+        cnf = self._load('-5')
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.epcsd_poll_interval_sec, 900)
+
+    def test_garbage_is_rejected(self):
+        cnf = self._load('quarter-hourly')
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.epcsd_poll_interval_sec, 900)
+
+    def test_the_default_is_fifteen_minutes(self):
+        with open(self.fname, 'w') as f:
+            f.write('[%s]\n' % TestEpcsdPollInterval.SECTION)
+        cnf = conf.SvcConf()
+        cnf.set_conf_file(self.fname)
+        self.assertEqual(cnf.epcsd_poll_interval_sec, 900)
 
 
 class TestParseController(unittest.TestCase):

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -156,6 +156,55 @@ class StasSysConfUnitTest(unittest.TestCase):
         self.assertEqual(system_conf.hostnqn, StasSysConfUnitTest.NQN)
 
 
+class TestDcGiveupTimeout(unittest.TestCase):
+    '''Unit tests for the dc-giveup-timeout encoding: "infinity" never gives
+    up, 0 gives up immediately, anything else is a time span.'''
+
+    SECTION = 'Discovery controller connection management'
+
+    def setUp(self):
+        fd, self.fname = tempfile.mkstemp(prefix='stas-giveup-', suffix='.conf')
+        os.close(fd)
+        self.addCleanup(os.remove, self.fname)
+        conf.SvcConf.destroy()
+        self.addCleanup(conf.SvcConf.destroy)
+
+    def _load(self, value):
+        with open(self.fname, 'w') as f:
+            f.write('[%s]\ndc-giveup-timeout=%s\n' % (TestDcGiveupTimeout.SECTION, value))
+        cnf = conf.SvcConf()
+        cnf.set_conf_file(self.fname)
+        return cnf
+
+    def test_infinity_never_gives_up(self):
+        # Carried as -1: that is what the code that arms the timer tests for.
+        self.assertEqual(self._load('infinity').dc_giveup_timeout_sec, -1)
+        self.assertEqual(self._load('INFINITY').dc_giveup_timeout_sec, -1)
+
+    def test_zero_gives_up_immediately(self):
+        self.assertEqual(self._load('0').dc_giveup_timeout_sec, 0)
+
+    def test_a_time_span_is_seconds(self):
+        self.assertEqual(self._load('72hours').dc_giveup_timeout_sec, 72 * 60 * 60)
+        self.assertEqual(self._load('3 days 5 hours').dc_giveup_timeout_sec, (3 * 24 + 5) * 60 * 60)
+
+    def test_a_unit_less_value_is_seconds_not_hours(self):
+        self.assertEqual(self._load('72').dc_giveup_timeout_sec, 72)
+
+    def test_a_negative_value_is_rejected(self):
+        '''"infinity" is how forever is spelled; -1 no longer means anything.'''
+        cnf = self._load('-1')
+        # The conversion is lazy: it happens when the property is read, not
+        # when the file is loaded, so the warning lands here.
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.dc_giveup_timeout_sec, 72 * 60 * 60)  # the default
+
+    def test_garbage_falls_back_to_the_default(self):
+        cnf = self._load('not-a-timespan')
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.dc_giveup_timeout_sec, 72 * 60 * 60)
+
+
 class TestParseController(unittest.TestCase):
     '''Unit tests for conf._parse_controller() — a pure function.'''
 

--- a/test/test-conn-conf.py
+++ b/test/test-conn-conf.py
@@ -208,10 +208,29 @@ class Test(unittest.TestCase):
             '[Discovery Controller]\n'
             'controller = transport=tcp;traddr=9.9.9.9;trsvcid=8009\n' % HOSTNQN
         )
-        self.assertFalse(cnf.reload())
+        with self.assertLogs(level='ERROR') as logs:
+            self.assertFalse(cnf.reload())
+        self.assertIn('keeping the previous one', logs.output[0])
+
         dcs = cnf.get_controllers(True)
         self.assertEqual(len(dcs), 1)
         self.assertEqual(dcs[0]['traddr'], '1.1.1.1')  # the good one, still there
+
+    def test_a_rejected_file_at_startup_says_so(self):
+        '''There is no previous configuration to keep the first time round, so
+        the daemon starts with nothing configured and must not claim otherwise.'''
+        self._write(
+            '[Host]\nhostnqn = %s\n'
+            '[Host]\nhostnqn = nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000002\n' % HOSTNQN
+        )
+        conf.ConnConf.destroy()
+        with self.assertLogs(level='ERROR') as logs:
+            cnf = conf.ConnConf(conf_file=self.fname)
+
+        self.assertIn('no controllers will be configured', logs.output[0])
+        self.assertNotIn('keeping the previous one', logs.output[0])
+        self.assertEqual(cnf.get_controllers(True), [])
+        self.assertEqual(cnf.get_controllers(False), [])
 
 
 if __name__ == '__main__':

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -113,12 +113,12 @@ zeroconf=enabled
 
 [Discovery controller connection management]
 persistent-connections=true
-zeroconf-connections-persistence=10 seconds
+dc-giveup-timeout=10 seconds
 '''
 
 stafd_conf_2 = '''
 [Discovery controller connection management]
-zeroconf-connections-persistence=-1
+dc-giveup-timeout=infinity
 '''
 
 stafd_conf_3 = '''
@@ -158,9 +158,7 @@ class Test(TestCase):
         default_conf = {
             ('Global', 'tron'): False,
             ('Discovery controller connection management', 'persistent-connections'): True,
-            ('Discovery controller connection management', 'zeroconf-connections-persistence'): timeparse.timeparse(
-                '72hours'
-            ),
+            ('Discovery controller connection management', 'dc-giveup-timeout'): timeparse.timeparse('72hours'),
             ('Global', 'ignore-iface'): False,
             ('Global', 'ip-family'): (4, 6),
             ('Global', 'pleo'): True,

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -73,6 +73,11 @@ class TestDc(ctrl.Dc):
 
 
 class TestStaf:
+    referral_eflags_value = None
+
+    def referral_eflags(self, tid):
+        return TestStaf.referral_eflags_value
+
     def is_avahi_reported(self, tid):
         return False
 
@@ -112,7 +117,6 @@ pleo=enabled
 zeroconf=enabled
 
 [Discovery controller connection management]
-persistent-connections=true
 dc-giveup-timeout=10 seconds
 '''
 
@@ -157,7 +161,7 @@ class Test(TestCase):
 
         default_conf = {
             ('Global', 'tron'): False,
-            ('Discovery controller connection management', 'persistent-connections'): True,
+            ('Discovery controller connection management', 'epcsd-poll-interval-minutes'): 15,
             ('Discovery controller connection management', 'dc-giveup-timeout'): timeparse.timeparse('72hours'),
             ('Global', 'ignore-iface'): False,
             ('Global', 'ip-family'): (4, 6),
@@ -506,6 +510,232 @@ class Test(TestCase):
 
         # _should_try_to_reconnect: ncc=False → max_connect_attempts=0 → always True
         self.assertTrue(ioc._should_try_to_reconnect())
+
+
+class TestPersistence(TestCase):
+    '''Unit tests for the EPCSD persistence policy of a discovery controller'''
+
+    EPCSD = 2  # NVMF_DISC_EFLAGS_EPCSD (bit 1; bit 2 is NCC)
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.create_file(
+            '/etc/nvme/hostnqn', contents='nqn.2014-08.org.nvmexpress:uuid:01234567-0123-0123-0123-0123456789ab\n'
+        )
+        self.fs.create_file('/etc/nvme/hostid', contents='01234567-89ab-cdef-0123-456789abcdef\n')
+        self.fs.create_file('/dev/nvme-fabrics', contents='instance=-1,cntlid=-1\n')
+        TestStaf.referral_eflags_value = None
+        self.addCleanup(setattr, TestStaf, 'referral_eflags_value', None)
+        conf.ConnConf.destroy()
+        self.addCleanup(conf.ConnConf.destroy)
+
+    def _dc(self, cfg=None, log_pages=None):
+        cid = {'transport': 'tcp', 'traddr': '1.1.1.1', 'trsvcid': '8009', 'subsysnqn': 'nqn.unrelated'}
+        if cfg:
+            cid.update(cfg)
+        return TestDc(TestStaf(), tid=trid.TID(cid), log_pages=log_pages)
+
+    def test_mode_defaults_to_auto(self):
+        '''libnvme treats an unset value as "no"; a discovery daemon cannot.'''
+        self.assertEqual(self._dc().persistence_mode(), 'auto')
+
+    def test_mode_comes_from_the_controller(self):
+        self.assertEqual(self._dc(cfg={'persistent': 'force'}).persistence_mode(), 'force')
+        self.assertEqual(self._dc(cfg={'persistent': 'no'}).persistence_mode(), 'no')
+
+    def test_an_unknown_mode_falls_back_to_auto(self):
+        self.assertEqual(self._dc(cfg={'persistent': 'sometimes'}).persistence_mode(), 'auto')
+
+    def test_epcsd_comes_from_the_self_entry(self):
+        dc = self._dc(log_pages=[{'subtype': ctrl.SUBTYPE_SELF, 'eflags': str(TestPersistence.EPCSD)}])
+        self.assertTrue(dc.epcsd())
+
+        dc = self._dc(log_pages=[{'subtype': ctrl.SUBTYPE_SELF, 'eflags': '0'}])
+        self.assertFalse(dc.epcsd())
+
+    def test_the_self_entry_wins_over_the_parent(self):
+        TestStaf.referral_eflags_value = 0
+        dc = self._dc(log_pages=[{'subtype': ctrl.SUBTYPE_SELF, 'eflags': str(TestPersistence.EPCSD)}])
+        self.assertTrue(dc.epcsd())
+
+    def test_the_parent_answers_when_there_is_no_self_entry(self):
+        TestStaf.referral_eflags_value = TestPersistence.EPCSD
+        dc = self._dc(log_pages=[{'subtype': ctrl.SUBTYPE_IOC, 'eflags': '0'}])
+        self.assertTrue(dc.epcsd())
+
+    def test_a_ddc_is_recognised_by_naming_both_spellings(self):
+        """DCTYPE was carved out of a field that defaults to 0, so a legacy DDC
+        reports "none" rather than "ddc". Both mean DDC; only a CDC is not one,
+        and an unknown future type must not be mistaken for one."""
+        dc = self._dc()
+        for dctype, expected in (('ddc', True), ('none', True), ('cdc', False), ('something-new', False)):
+            dc._ctrl.dctype = dctype
+            with self.subTest(dctype=dctype):
+                self.assertEqual(dc._is_ddc(), expected)
+
+    def test_only_a_discovery_controller_can_be_parked(self):
+        """parked() is asked of every controller when one is removed, so it has
+        to answer for I/O controllers too."""
+        ioc = TestIoc(TestStaf(), tid=trid.TID({'transport': 'tcp', 'traddr': '1.1.1.1', 'subsysnqn': 'nqn.x'}))
+        self.assertFalse(ioc.parked())
+
+    def test_no_self_entry_and_no_parent_means_no(self):
+        '''What libnvme's dc_decide() and nvme-discoverd both assume.'''
+        self.assertFalse(self._dc().epcsd())
+
+
+class ParkableDc(TestDc):
+    '''A Dc whose disconnect is recorded rather than performed, so parking can
+    be tested without a main loop.'''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disconnects = []
+
+    def disconnect(self, disconnected_cb, keep_connection):
+        self.disconnects.append(keep_connection)
+        self._connected = False
+
+
+class TestParking(TestCase):
+    '''Unit tests for parking: a discovery controller that does not support a
+    persistent connection is disconnected but kept, and polled.'''
+
+    EPCSD = 2
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.create_file(
+            '/etc/nvme/hostnqn', contents='nqn.2014-08.org.nvmexpress:uuid:01234567-0123-0123-0123-0123456789ab\n'
+        )
+        self.fs.create_file('/etc/nvme/hostid', contents='01234567-89ab-cdef-0123-456789abcdef\n')
+        self.fs.create_file('/dev/nvme-fabrics', contents='instance=-1,cntlid=-1\n')
+        TestStaf.referral_eflags_value = None
+        self.addCleanup(setattr, TestStaf, 'referral_eflags_value', None)
+        conf.ConnConf.destroy()
+        self.addCleanup(conf.ConnConf.destroy)
+
+    def _dc(self, persistent=None, eflags=0, origin='discovered'):
+        cid = {'transport': 'tcp', 'traddr': '1.1.1.1', 'trsvcid': '8009', 'subsysnqn': 'nqn.unrelated'}
+        if persistent:
+            cid['persistent'] = persistent
+        dc = ParkableDc(
+            TestStaf(),
+            tid=trid.TID(cid),
+            log_pages=[{'subtype': ctrl.SUBTYPE_SELF, 'eflags': str(eflags)}],
+            origin=origin,
+        )
+        return dc
+
+    def test_auto_parks_a_dc_without_epcsd(self):
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+        self.assertEqual(dc.disconnects, [False])  # do not keep the connection
+
+    def test_auto_holds_a_dc_with_epcsd(self):
+        dc = self._dc(eflags=TestParking.EPCSD)
+        dc._apply_persistence_policy()
+        self.assertFalse(dc.parked())
+        self.assertEqual(dc.disconnects, [])
+
+    def test_force_never_parks(self):
+        '''For a DC whose own EPCSD cannot be trusted.'''
+        dc = self._dc(persistent='force', eflags=0)
+        dc._apply_persistence_policy()
+        self.assertFalse(dc.parked())
+        self.assertEqual(dc.disconnects, [])
+
+    def test_no_parks_even_with_epcsd(self):
+        dc = self._dc(persistent='no', eflags=TestParking.EPCSD)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+
+    def test_parking_is_not_repeated(self):
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        dc._apply_persistence_policy()
+        self.assertEqual(dc.disconnects, [False])
+
+    def test_a_dc_unparks_when_epcsd_appears(self):
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+
+        dc._log_pages = [{'subtype': ctrl.SUBTYPE_SELF, 'eflags': str(TestParking.EPCSD)}]
+        dc._apply_persistence_policy()
+        self.assertFalse(dc.parked())
+
+    def test_a_parked_dc_is_not_treated_as_lost(self):
+        '''It is disconnected because we disconnected it, not because it went
+        away, so the give-up timer must not start counting toward deletion.'''
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+
+        dc._handle_lost_controller()
+        self.assertEqual(dc._ctrl_unresponsive_time, None)
+
+    def test_a_dc_that_really_is_lost_still_counts(self):
+        '''The guard must not swallow the case it is guarding against.'''
+        dc = self._dc(eflags=TestParking.EPCSD)
+        dc._apply_persistence_policy()
+        self.assertFalse(dc.parked())
+
+        dc.set_connected(False)
+        dc._handle_lost_controller()
+        self.assertIsNotNone(dc._ctrl_unresponsive_time)
+
+    def test_get_supported_failure_fetches_the_log_pages_anyway(self):
+        """A controller that answers "unrecognized" will not answer differently
+        on a second try, and PLEOS is only consulted to decide whether to set
+        PLEO. Retrying instead meant never retrieving the log pages at all."""
+        dc = self._dc(eflags=0)
+
+        class Op:
+            killed = False
+
+            def kill(self):
+                Op.killed = True
+
+            def retry(self, _interval):
+                raise AssertionError('must not retry')
+
+        with self.assertLogs(level='ERROR'):
+            dc._on_get_supported_fail(Op(), 'NvmeError: unrecognized', 1)
+
+        self.assertTrue(Op.killed)
+        self.assertIsNone(dc._get_supported_op)
+        self.assertIsNotNone(dc._get_log_op)  # went on to fetch the log pages
+
+    def test_a_self_entry_survives_the_address_filter(self):
+        """A CDC may report an unusable address; those entries are dropped.
+        The controller's own entry is exempt: it is not something we dial, and
+        its EFLAGS are where EPCSD comes from."""
+        dc = self._dc(eflags=0)
+        dc._on_get_log_success(
+            None,
+            [
+                {'subtype': ctrl.SUBTYPE_SELF, 'traddr': '0.0.0.0', 'eflags': str(TestParking.EPCSD)},
+                {'subtype': ctrl.SUBTYPE_IOC, 'traddr': '0.0.0.0', 'subnqn': 'nqn.dropped'},
+                {'subtype': ctrl.SUBTYPE_IOC, 'traddr': '1.1.1.1', 'subnqn': 'nqn.kept'},
+            ],
+        )
+
+        subnqns = [page.get('subnqn') for page in dc.log_pages()]
+        self.assertIn('nqn.kept', subnqns)
+        self.assertNotIn('nqn.dropped', subnqns)  # unusable address, still filtered
+
+        self.assertIsNotNone(dc._self_entry())
+        self.assertTrue(dc.epcsd())  # and it is what we read EPCSD from
+
+    def test_the_poll_timer_brings_it_back(self):
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+
+        dc._on_epcsd_poll_expired()
+        self.assertFalse(dc.parked())
 
 
 if __name__ == '__main__':

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import unittest
-from staslib import conf, log, service
+from staslib import conf, ctrl, log, service, trid
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 
@@ -122,6 +122,145 @@ class TestCtrlTerminator(unittest.TestCase):
         term.kill()
         self.assertEqual(removed, [True])
 
+
+class FakeDc:
+    '''Just enough of a discovery controller for referral_eflags().'''
+
+    def __init__(self, tid, referrals):
+        self.tid = tid
+        self._referrals = referrals
+
+    def referrals(self):
+        return self._referrals
+
+
+class FakeStaf:
+    '''Stands in for the service. referral_eflags() reaches for nothing else,
+    so the real method can be called against this.'''
+
+    def __init__(self, controllers):
+        self._controllers = controllers
+
+    def get_controllers(self):
+        return self._controllers
+
+
+class TestReferralEflags(unittest.TestCase):
+    '''Unit tests for Staf.referral_eflags(): what a discovery controller
+    published about another one it referred us to.'''
+
+    EPCSD = 2
+
+    HOST_TRADDR = '1.2.3.4'
+    HOST_IFACE = 'eth0'
+    HOSTNQN = 'nqn.2014-08.org.nvmexpress:uuid:01234567-0123-0123-0123-0123456789ab'
+
+    @staticmethod
+    def _parent(referrals):
+        parent_tid = trid.TID(
+            {
+                'transport': 'tcp',
+                'traddr': '1.1.1.1',
+                'trsvcid': '8009',
+                'subsysnqn': 'nqn.2014-08.org.nvmexpress.discovery',
+                'host-traddr': TestReferralEflags.HOST_TRADDR,
+                'host-iface': TestReferralEflags.HOST_IFACE,
+                'hostnqn': TestReferralEflags.HOSTNQN,
+            }
+        )
+        return FakeDc(parent_tid, referrals)
+
+    @staticmethod
+    def _referral_dlpe(traddr, eflags):
+        return {
+            'subtype': ctrl.SUBTYPE_REFERRAL,
+            'trtype': 'tcp',
+            'traddr': traddr,
+            'trsvcid': '8009',
+            'subnqn': 'nqn.2014-08.org.nvmexpress.discovery',
+            'eflags': str(eflags),
+        }
+
+    @staticmethod
+    def _referred_tid(traddr):
+        '''The TID the parent's referral entry designates. Spelled out rather
+        than built with tid_from_dlpe(), so this does not merely agree with
+        itself.'''
+        return trid.TID(
+            {
+                'transport': 'tcp',
+                'traddr': traddr,
+                'trsvcid': '8009',
+                'subsysnqn': 'nqn.2014-08.org.nvmexpress.discovery',
+                'host-traddr': TestReferralEflags.HOST_TRADDR,
+                'host-iface': TestReferralEflags.HOST_IFACE,
+                'hostnqn': TestReferralEflags.HOSTNQN,
+            }
+        )
+
+    def _lookup(self, controllers, tid):
+        return service.Staf.referral_eflags(FakeStaf(controllers), tid)
+
+    def test_finds_what_the_parent_published(self):
+        parent = self._parent([self._referral_dlpe('2.2.2.2', TestReferralEflags.EPCSD)])
+        self.assertEqual(self._lookup([parent], self._referred_tid('2.2.2.2')), TestReferralEflags.EPCSD)
+
+    def test_zero_is_an_answer_not_an_absence(self):
+        '''A parent saying "no EPCSD" must be distinguishable from no parent
+        at all: the caller falls back only on None.'''
+        parent = self._parent([self._referral_dlpe('2.2.2.2', 0)])
+        self.assertEqual(self._lookup([parent], self._referred_tid('2.2.2.2')), 0)
+
+    def test_none_when_nobody_refers_to_it(self):
+        parent = self._parent([self._referral_dlpe('2.2.2.2', TestReferralEflags.EPCSD)])
+        self.assertIsNone(self._lookup([parent], self._referred_tid('9.9.9.9')))
+
+    def test_none_when_there_are_no_controllers(self):
+        self.assertIsNone(self._lookup([], self._referred_tid('2.2.2.2')))
+
+    def test_searches_every_controller(self):
+        quiet = self._parent([])
+        talkative = self._parent([self._referral_dlpe('3.3.3.3', TestReferralEflags.EPCSD)])
+        self.assertEqual(
+            self._lookup([quiet, talkative], self._referred_tid('3.3.3.3')), TestReferralEflags.EPCSD
+        )
+
+
+class TestDefaultConf(unittest.TestCase):
+    '''SvcConf builds its valid-option set from the daemon's DEFAULT_CONF, not
+    from OPTION_CHECKER, so an option missing there is rejected as invalid no
+    matter how well OPTION_CHECKER knows it. These pin that both ways.'''
+
+    DAEMONS = (('stafd', service.Staf), ('stacd', service.Stac))
+
+    def test_every_default_is_a_known_option(self):
+        '''A typo in DEFAULT_CONF would otherwise sit there unnoticed.'''
+        for name, daemon in TestDefaultConf.DAEMONS:
+            for section, option in daemon.DEFAULT_CONF:
+                with self.subTest(daemon=name, section=section, option=option):
+                    self.assertIn(section, conf.SvcConf.OPTION_CHECKER)
+                    self.assertIn(option, conf.SvcConf.OPTION_CHECKER[section])
+
+    def test_each_daemon_accepts_its_whole_section(self):
+        '''The section that belongs to a daemon must be listed in full. This is
+        what catches an option added to OPTION_CHECKER and to the shipped .conf
+        file, but forgotten here - the daemon would reject it as invalid.'''
+        owned = {
+            'stafd': 'Discovery controller connection management',
+            'stacd': 'I/O controller connection management',
+        }
+        for name, daemon in TestDefaultConf.DAEMONS:
+            section = owned[name]
+            declared = {opt for sect, opt in daemon.DEFAULT_CONF if sect == section}
+            with self.subTest(daemon=name, section=section):
+                self.assertEqual(declared, set(conf.SvcConf.OPTION_CHECKER[section]))
+
+    def test_the_common_sections_are_covered(self):
+        '''Both daemons read [Global] tron and [Controllers] exclude.'''
+        for name, daemon in TestDefaultConf.DAEMONS:
+            with self.subTest(daemon=name):
+                self.assertIn(('Global', 'tron'), daemon.DEFAULT_CONF)
+                self.assertIn(('Controllers', 'exclude'), daemon.DEFAULT_CONF)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Whether nvme-stas holds a discovery controller's connection open is now decided by the controller itself, through the EPCSD bit it reports in its own discovery log page entry, rather than by a single daemon-wide flag that assumed every DC could keep a connection.

The knob is the `persistent` key of `/etc/nvme/nvme-stas.conf` — `no`, `auto` or `force` — which libnvme already parses and cascades, and which can be set per DC. It defaults to `auto`: hold the connection open wherever the DC reports it supports one. That differs from libnvme, whose unset value behaves as `no`, because a daemon whose purpose is to be told when log pages change cannot default to disconnecting. nvme-discoverd makes the same choice.

## What changes

**A DC that does not support a persistent connection is parked**: stafd disconnects, keeps the cached log pages, and re-reads them every `epcsd-poll-interval-minutes`, since such a DC cannot tell us they changed. A parked DC must not look like one that has gone away, so neither the udev removal following our own disconnect nor the unresponsive-controller timer treats it as lost, and what to keep connected on exit is now whatever is still held open rather than a configuration flag.

**The entry a DC publishes about itself is no longer discarded** by the address filter. It is not an address we dial, and its EFLAGS are where EPCSD comes from. Nothing connects it either way: the referral list takes only referral entries, and stacd only NVM subsystem ones.

**Failing to Get Supported Log Pages no longer retries.** This fixes a real, pre-existing bug: with the default `pleo=enabled`, a DC that could not answer it had its discovery log page never read at all — the retry fired every 5 seconds forever and the fetch never started, so stacd learned of no I/O controllers, with one throttled debug line as the only clue. A plain nvmet target does exactly this: 0 successes and 65 failures over a day of coverage runs. Since PLEOS is only consulted to decide whether to set PLEO, stafd now assumes PLEOS=0 and gets the log pages.

**A rejected connectivity configuration no longer claims to keep one that never existed.** The message is right on a reload, but at startup there is nothing to keep.

## Configuration changes

| `stafd.conf` key | Change |
|---|---|
| `persistent-connections` | Removed. Replaced by the `persistent` key of `/etc/nvme/nvme-stas.conf`, settable per DC. |
| `epcsd-poll-interval-minutes` | New. How often to re-read a parked DC's log pages. Default 15, minimum 1 — 0 is invalid, as the poll is the only way back. |
| `zeroconf-connections-persistence` | Renamed `dc-giveup-timeout` and encoded as systemd spells a time span: `infinity` never gives up, `0` gives up immediately, otherwise a span whose unit is seconds. The old `-1` is rejected. |

The rename converges with nvme-discoverd on one name and one encoding. The unit stays in `epcsd-poll-interval-minutes`'s name on purpose: a give-up timer spans hours to days, while a poll interval must not go below a minute, and integer minutes make that a hard floor.

## Dependency

Requires nvme-cli PR #3948, which has merged: discovery log page subtypes are now matched against libnvme's own decoder strings.

## Verification

`meson test`: 129 OK, 2 expected failures, 0 failures.

The nvmet-based coverage run passes clean at 93%, and gained a phase that parks a DC and waits out the poll. `Retry in 5 sec` went from roughly 20 messages per run to none, and the run now performs 13 log page retrievals where it previously got them only in the two phases that disable PLEO. Note that nvmet always reports `eflags=0`, so every DC it serves says EPCSD=0; the phases needing held-open connections set `persistent = force`.
