### PR TITLE
ci: lint staslib, which the linters never looked at

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -56,12 +56,12 @@ jobs:
 
       - name: "Ruff: lint"
         run: |
-          ruff check --diff .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
+          ruff check --diff --no-respect-gitignore .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
 
       - name: "Ruff: format"
         if: always()
         run: |
-          ruff format --check --diff .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
+          ruff format --check --diff --no-respect-gitignore .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
 
   python-lint-Noble:
     runs-on: ubuntu-24.04
@@ -109,9 +109,9 @@ jobs:
 
       - name: "Ruff: lint"
         run: |
-          ruff check --diff .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
+          ruff check --diff --no-respect-gitignore .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
 
       - name: "Ruff: format"
         if: always()
         run: |
-          ruff format --check --diff .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib
+          ruff format --check --diff --no-respect-gitignore .build/stacctl .build/stacd .build/stafctl .build/stafd .build/staslib


### PR DESCRIPTION
The Ruff steps name .build/stacctl, .build/stacd, .build/stafctl, .build/stafd and .build/staslib, but .build is the first line of .gitignore. Ruff honours it while traversing a directory, so .build/staslib expanded to nothing; the four scripts were checked only because an explicit file path bypasses the filter. Four files linted where there should have been twenty.

--no-respect-gitignore is what test/meson.build already passes, which is why "meson test" has been catching things CI does not. The library is clean under both check and format, so this puts sixteen more files under the linters without changing any of them.