### PR TITLE
staslib: do not disconnect I/O controllers we were never told about

### DIFF
--- a/staslib/service.py
+++ b/staslib/service.py
@@ -292,13 +292,19 @@ class Stac(Service):
         return GLib.SOURCE_CONTINUE
 
     def _get_log_pages_from_stafd(self):
+        '''Return stafd's discovery log pages, or None if stafd could not be reached.
+
+        None and an empty list mean different things. An empty list is stafd
+        telling us that nothing is discovered, which is information we can act
+        on. None is stafd telling us nothing at all, which is not.
+        '''
         if self._staf:
             try:
                 return json.loads(self._staf.get_all_log_pages(True))
             except dasbus.error.DBusError as ex:
                 logging.debug('Stac._get_log_pages_from_stafd()   - %s', ex)
 
-        return list()
+        return None
 
     def _config_ctrls_finish(self, configured_ctrl_list: list):
         '''Finish I/O controller configuration after hostname resolution, then reconcile running controllers.'''
@@ -316,8 +322,10 @@ class Stac(Service):
 
         logging.debug('Stac._config_ctrls_finish()        - configured_ctrl_list = %s', configured_ctrl_list)
 
+        staf_data_list = self._get_log_pages_from_stafd()
+
         discovered_ctrls = dict()
-        for staf_data in self._get_log_pages_from_stafd():
+        for staf_data in staf_data_list or list():
             host_traddr = staf_data['discovery-controller']['host-traddr']
             host_iface = staf_data['discovery-controller']['host-iface']
             hostnqn = staf_data['discovery-controller']['hostnqn']
@@ -336,7 +344,17 @@ class Stac(Service):
         new_controller_tids = set(controllers)
         cur_controller_tids = set(self._controllers.keys())
         controllers_to_add = new_controller_tids - cur_controller_tids
-        controllers_to_del = cur_controller_tids - new_controller_tids
+
+        # Everything we learn through discovery comes from stafd. While we
+        # cannot reach it, a controller missing from the list above is missing
+        # because nobody told us about it, not because it went away. Acting on
+        # that would disconnect every controller we ever discovered, so until
+        # stafd answers again we only add.
+        if staf_data_list is None:
+            controllers_to_del = set()
+            logging.debug('Stac._config_ctrls_finish()        - Nothing heard from stafd. Removing no controller.')
+        else:
+            controllers_to_del = cur_controller_tids - new_controller_tids
 
         logging.debug('Stac._config_ctrls_finish()        - controllers_to_add   = %s', list(controllers_to_add))
         logging.debug('Stac._config_ctrls_finish()        - controllers_to_del   = %s', list(controllers_to_del))

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -2,6 +2,7 @@
 import os
 import logging
 import unittest
+import unittest.mock
 from staslib import conf, ctrl, log, service, trid
 from pyfakefs.fake_filesystem_unittest import TestCase
 
@@ -261,6 +262,56 @@ class TestDefaultConf(unittest.TestCase):
             with self.subTest(daemon=name):
                 self.assertIn(('Global', 'tron'), daemon.DEFAULT_CONF)
                 self.assertIn(('Controllers', 'exclude'), daemon.DEFAULT_CONF)
+
+
+class TestStacReconcileWithoutStafd(unittest.TestCase):
+    '''stacd learns about I/O controllers from stafd and from nowhere else. When
+    stafd cannot be reached, an I/O controller missing from the discovery log
+    pages is missing because nobody told us about it, not because it went away.
+    These pin that stacd tells the two apart.'''
+
+    TID = trid.TID(
+        {
+            'transport': 'tcp',
+            'traddr': '10.10.10.10',
+            'trsvcid': '4420',
+            'subsysnqn': 'nqn.1988-11.com.dell:PowerSANxxx:01:20210225100113-454f73093ceb4847a7bdfc6e34ae8e28',
+        }
+    )
+
+    def setUp(self):
+        conf.SvcConf.destroy()  # Make sure singleton does not exist
+        self.addCleanup(conf.SvcConf.destroy)
+        conf.SvcConf(default_conf=service.Stac.DEFAULT_CONF)
+
+    def _make_stac(self, log_pages):
+        '''Build the smallest object _config_ctrls_finish() will run against, holding
+        one I/O controller and told to expect @log_pages back from stafd.'''
+        stac = unittest.mock.Mock()  # No spec: _udev and friends are instance attributes
+        stac._alive = lambda: True
+        stac._get_log_pages_from_stafd = lambda: log_pages
+        stac._udev.find_nvme_ioc_device = lambda tid: None
+        stac._controllers = {TestStacReconcileWithoutStafd.TID: unittest.mock.Mock()}
+        return stac
+
+    def test_no_controller_is_removed_when_stafd_is_unreachable(self):
+        '''None means "we were told nothing", so nothing may be disconnected.'''
+        stac = self._make_stac(None)
+
+        service.Stac._config_ctrls_finish(stac, list())
+
+        stac._terminator.dispose.assert_not_called()
+        self.assertIn(TestStacReconcileWithoutStafd.TID, stac._controllers)
+
+    def test_a_controller_is_removed_when_stafd_reports_nothing(self):
+        '''An empty list means "nothing is discovered", which we can act on.'''
+        stac = self._make_stac(list())
+
+        service.Stac._config_ctrls_finish(stac, list())
+
+        stac._terminator.dispose.assert_called_once()
+        self.assertNotIn(TestStacReconcileWithoutStafd.TID, stac._controllers)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
stacd learns about I/O controllers from stafd and from nowhere else, and _get_log_pages_from_stafd() returned an empty list whether stafd said there was nothing to report or could not be reached at all. The reconcile that follows cannot tell those apart, so an unreachable stafd read as "nothing is discovered": every controller stacd had learned through discovery landed in controllers_to_del and, with honor-fabric-zoning enabled as it is by default, was disconnected.

Nothing orders stacd after stafd - stacd.service does not mention it - and the startup soak is 1.5 seconds, so this needs no outage to happen, only stafd being slow to claim its bus name.

Return None when stafd could not be reached and keep the removal pass for the case where it answered. Controllers are still added while stafd is down, so a controller named in the connectivity configuration still gets connected; we just never conclude that a controller went away from an answer we did not get.