### PR TITLE
staslib: let stacd work out what it was managing instead of remembering

### DIFF
--- a/staslib/service.py
+++ b/staslib/service.py
@@ -9,7 +9,9 @@
 '''This module defines the base Service object from
 which the Staf and the Stac objects are derived.'''
 
+import os
 import json
+import pickle
 import logging
 import pathlib
 from itertools import filterfalse
@@ -250,23 +252,28 @@ class Stac(Service):
         self._staf_watcher = None
 
     def _dump_last_known_config(self, controllers):
-        config = list(controllers.keys())
-        logging.debug('Stac._dump_last_known_config()     - IOC count = %s', len(config))
-        self._write_lkc(config)
+        '''Nothing to save. What stacd is managing is already recorded where it
+        cannot go stale: the connection exists in the kernel, and the registry
+        entry beside it names us as its owner.'''
 
     def _load_last_known_config(self):
-        config = self._read_lkc() or list()
-        logging.debug('Stac._load_last_known_config()     - IOC count = %s', len(config))
+        '''Re-adopt the I/O controller connections we made before restarting.
 
+        The kernel lists what is connected and the registry says who made each
+        one; between them there is nothing left for stacd to remember. Note
+        that this asks for connections owned by us, not merely for ones nobody
+        else owns - an unowned connection predates the registry or belongs to
+        somebody who never registered it, and adopting it would be taking over
+        a connection we never made.
+        '''
         controllers = {}
-        for tid in config:
-            # Only create Ioc objects if there is already a connection in the kernel
-            # First, regenerate the TID (in case of soft. upgrade and TID object
-            # has changed internally)
-            tid = trid.TID(tid.as_dict())
-            if udev.UDEV.find_nvme_ioc_device(tid) is not None:
-                controllers[tid] = ctrl.Ioc(self, tid)
+        for device, tid in udev.UDEV.get_ioc_tids().items():
+            if not stas.owned_by_us(device):
+                continue
+            logging.debug('Stac._load_last_known_config()     - %s | %s: adopted', tid, device)
+            controllers[tid] = ctrl.Ioc(self, tid)
 
+        logging.debug('Stac._load_last_known_config()     - IOC count = %s', len(controllers))
         return controllers
 
     def _keep_connections_on_exit(self):
@@ -377,8 +384,6 @@ class Stac(Service):
             if tid in discovered_ctrls:
                 dlpe = discovered_ctrls[tid]
                 controller.update_dlpe(dlpe)
-
-        self._dump_last_known_config(self._controllers)
 
     def _connect_to_staf(self, _):
         '''Connect to the stafd D-Bus interface and hook up signal handlers.'''
@@ -491,6 +496,10 @@ class Staf(Service):
     CONFIGURES_DCS = True
 
     def __init__(self, args, dbus):
+        # Set before super().__init__(), which calls _load_last_known_config().
+        self._lkc_file = os.path.join(
+            os.environ.get('RUNTIME_DIRECTORY', os.path.join('/run', defs.PROG_NAME)), 'last-known-config.pickle'
+        )
         super().__init__(args, Staf.DEFAULT_CONF, self._reload_hdlr)
 
         self._avahi = avahi.Avahi(self._sysbus, self._avahi_change)
@@ -504,8 +513,34 @@ class Staf(Service):
     def info(self) -> dict:
         '''Return the status info for this object (used for debug).'''
         info = super().info()
+        info['last known config file'] = self._lkc_file
         info['avahi'] = self._avahi.info()
         return info
+
+    def _read_lkc(self):
+        '''Read the last known config from file.
+
+        Security note: pickle.load() is used here. This is safe because the
+        LKC file is written exclusively by this process to a path under
+        RUNTIME_DIRECTORY (e.g. /run/nvme-stas/), which is only writable by
+        root. No untrusted data can reach this code path.
+        '''
+        try:
+            with open(self._lkc_file, 'rb') as file:
+                return pickle.load(file)
+        except (FileNotFoundError, AttributeError, EOFError, pickle.UnpicklingError):
+            return None
+
+    def _write_lkc(self, config):
+        '''Write the last known config to file. If config is empty, the file is truncated.'''
+        try:
+            # Note that if config is empty we still
+            # want to open/close the file to empty it.
+            with open(self._lkc_file, 'wb') as file:
+                if config:
+                    pickle.dump(config, file)
+        except FileNotFoundError as ex:
+            logging.error('Unable to save last known config: %s', ex)
 
     def _release_resources(self):
         logging.debug('Staf._release_resources()')

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -13,7 +13,6 @@ import os
 import sys
 import abc
 import signal
-import pickle
 import logging
 import dasbus.connection
 from gi.repository import Gio, GLib
@@ -206,6 +205,20 @@ def _owner(device):
         # A registry we can't read must not get in the way of a teardown.
         logging.warning('Unable to read the registry entry of %s: %s', device, ex)
         return None
+
+
+# ******************************************************************************
+def owned_by_us(device):
+    '''Return True if the registry says this connection is one of ours.
+
+    Note that this asks a different question from protected(), which lets an
+    unowned connection through: a connection nobody has claimed is one we may
+    take over. Here we are deciding what to adopt when we start with no memory
+    of what we were doing, and an unowned connection is precisely what we must
+    not take: it is somebody else's doing, or it predates the registry. Only
+    an entry naming us says we made it.
+    '''
+    return _owner(device) == defs.REGISTRY_OWNER
 
 
 # ******************************************************************************
@@ -485,9 +498,6 @@ class ServiceABC(abc.ABC):
         self._tron = args.tron or service_conf.tron
         log.set_level_from_tron(self._tron)
 
-        self._lkc_file = os.path.join(
-            os.environ.get('RUNTIME_DIRECTORY', os.path.join('/run', defs.PROG_NAME)), 'last-known-config.pickle'
-        )
         self._loop = GLib.MainLoop()
         self._cancellable = Gio.Cancellable()
         self._resolver = gutil.NameResolver()
@@ -531,7 +541,6 @@ class ServiceABC(abc.ABC):
         self._cfg_soak_tmr = None
         self._cancellable = None
         self._resolver = None
-        self._lkc_file = None
         self._sysbus = None
 
     def _config_dbus(self, iface_obj, bus_name: str, obj_name: str):
@@ -565,7 +574,6 @@ class ServiceABC(abc.ABC):
         '''Return the status info for this object (used for debug).'''
         nvme_options = conf.NvmeOptions()
         info = conf.SysConf().as_dict()
-        info['last known config file'] = self._lkc_file
         info['config soak timer'] = str(self._cfg_soak_tmr)
         info['kernel support.TP8013'] = str(nvme_options.discovery_supp)
         info['kernel support.host_iface'] = str(nvme_options.host_iface_supp)
@@ -702,31 +710,6 @@ class ServiceABC(abc.ABC):
         configured_controllers = remove_excluded(configured_controllers)
         self._resolver.resolve_ctrl_async(self._cancellable, configured_controllers, self._config_ctrls_finish)
 
-    def _read_lkc(self):
-        '''Read the last known config from file.
-
-        Security note: pickle.load() is used here. This is safe because the
-        LKC file is written exclusively by this process to a path under
-        RUNTIME_DIRECTORY (e.g. /run/nvme-stas/), which is only writable by
-        root. No untrusted data can reach this code path.
-        '''
-        try:
-            with open(self._lkc_file, 'rb') as file:
-                return pickle.load(file)
-        except (FileNotFoundError, AttributeError, EOFError, pickle.UnpicklingError):
-            return None
-
-    def _write_lkc(self, config):
-        '''Write the last known config to file. If config is empty, the file is truncated.'''
-        try:
-            # Note that if config is empty we still
-            # want to open/close the file to empty it.
-            with open(self._lkc_file, 'wb') as file:
-                if config:
-                    pickle.dump(config, file)
-        except FileNotFoundError as ex:
-            logging.error('Unable to save last known config: %s', ex)
-
     @abc.abstractmethod
     def _disconnect_all(self):
         '''Tell all controller objects to disconnect'''
@@ -746,8 +729,14 @@ class ServiceABC(abc.ABC):
 
     @abc.abstractmethod
     def _load_last_known_config(self):
-        '''Load last known config from file (if any)'''
+        '''Return the controllers this service was already managing, if any.
+
+        Called at startup, before the main loop runs. What "already managing"
+        means is the service's own business: stafd remembers what it had,
+        stacd works it out from the connections on the system.'''
 
     @abc.abstractmethod
     def _dump_last_known_config(self, controllers):
-        '''Save last known config to file'''
+        '''Record what this service is managing, for _load_last_known_config()
+        to find after a restart. A service that can work it out from the system
+        has nothing to do here.'''

--- a/staslib/udev.py
+++ b/staslib/udev.py
@@ -14,7 +14,7 @@ import logging
 from functools import partial
 import pyudev
 from gi.repository import GLib
-from staslib import defs, iputil
+from staslib import defs, iputil, trid
 
 
 # ******************************************************************************
@@ -429,6 +429,35 @@ class Udev:
             return attr_str[start:]
 
         return attr_str[start:end]
+
+    def get_ioc_tids(self) -> dict:
+        '''Return {sys_name: TID} for every I/O controller connection on the system.
+
+        This is how stacd finds the connections it was managing before it
+        restarted. The kernel is the only thing that knows what is actually
+        connected; whether a connection is ours is a separate question, which
+        the ownership registry answers.
+        '''
+        ifaces = iputil.net_if_addrs()
+        return {
+            device.sys_name: self.get_tid(device, ifaces)
+            for device in self._context.list_devices(subsystem='nvme')
+            if self.is_ioc_device(device)
+        }
+
+    @staticmethod
+    def get_tid(device, ifaces):
+        '''Return the Transport ID (TID) associated with a udev device.'''
+        cid = Udev.get_cid(device)
+        if cid['transport'] == 'tcp':
+            src_addr = cid['src-addr']
+            if not cid['host-iface'] and src_addr:
+                # We'll try to find the interface from the source address on
+                # the connection. Only available if kernel exposes the source
+                # address (src_addr) in the "address" attribute.
+                cid['host-iface'] = iputil.get_interface(ifaces, iputil.get_ipaddress_obj(src_addr))
+
+        return trid.TID(cid)
 
     @staticmethod
     def get_cid(device):

--- a/test/test-service.py
+++ b/test/test-service.py
@@ -1,9 +1,13 @@
 #!/usr/bin/python3
 import os
+import atexit
+import shutil
 import logging
+import tempfile
 import unittest
 import unittest.mock
-from staslib import conf, ctrl, log, service, trid
+from libnvme3 import nvme
+from staslib import conf, ctrl, defs, log, service, trid, udev
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 
@@ -311,6 +315,78 @@ class TestStacReconcileWithoutStafd(unittest.TestCase):
 
         stac._terminator.dispose.assert_called_once()
         self.assertNotIn(TestStacReconcileWithoutStafd.TID, stac._controllers)
+
+
+def libnvme_sandbox():
+    '''Return a directory where libnvme reads its host-wide config files.
+
+    libnvme's test base dir is process-global and only the first call takes
+    effect, so every test file that needs one must agree on the same path:
+    "meson test" runs each file in its own process, but pytest runs them all
+    in one. The path must be under /tmp.
+    '''
+    path = os.path.join(tempfile.gettempdir(), 'nvme-stas-test-%d' % os.getpid())
+    if not os.path.exists(path):
+        os.makedirs(path)
+        atexit.register(shutil.rmtree, path, ignore_errors=True)
+    conf.libnvme_ctx().set_test_base_dir(path)
+    return path
+
+
+class TestStacAdoptOnStartup(unittest.TestCase):
+    '''stacd has no memory of its own across a restart: it re-adopts the I/O
+    controllers it was managing by asking the kernel what is connected and the
+    registry who owns each one. These pin which connections that takes.'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.SANDBOX = libnvme_sandbox()
+
+    def _register(self, device, owner):
+        nvme.registry_update(conf.libnvme_ctx(), device, 'owner', owner)
+        self.addCleanup(nvme.registry_delete, conf.libnvme_ctx(), device)
+
+    @staticmethod
+    def _tid(traddr):
+        return trid.TID({'transport': 'tcp', 'traddr': traddr, 'trsvcid': '4420', 'subsysnqn': 'nqn.probe'})
+
+    def _adopted(self, ioc_tids):
+        '''Run the startup scan over @ioc_tids and return the TIDs it adopted.'''
+        stac = unittest.mock.Mock()
+        with unittest.mock.patch.object(udev.UDEV, 'get_ioc_tids', return_value=ioc_tids):
+            with unittest.mock.patch.object(ctrl, 'Ioc', side_effect=lambda serv, tid: tid):
+                return service.Stac._load_last_known_config(stac)
+
+    def test_a_connection_we_own_is_adopted(self):
+        self._register('nvme71', defs.REGISTRY_OWNER)
+        tid = TestStacAdoptOnStartup._tid('10.10.10.71')
+
+        self.assertEqual(list(self._adopted({'nvme71': tid})), [tid])
+
+    def test_a_connection_owned_by_somebody_else_is_left_alone(self):
+        self._register('nvme72', 'discoverd')
+
+        self.assertEqual(self._adopted({'nvme72': TestStacAdoptOnStartup._tid('10.10.10.72')}), {})
+
+    def test_an_unowned_connection_is_not_adopted(self):
+        '''The one that separates this from protected(), which lets an unowned
+        connection through. Here, nothing naming us means we did not make it.'''
+        self.assertEqual(self._adopted({'nvme73': TestStacAdoptOnStartup._tid('10.10.10.73')}), {})
+
+    def test_only_the_connections_we_own_are_picked_out_of_a_mixed_bag(self):
+        self._register('nvme74', defs.REGISTRY_OWNER)
+        self._register('nvme75', 'discoverd')
+        ours = TestStacAdoptOnStartup._tid('10.10.10.74')
+
+        adopted = self._adopted(
+            {
+                'nvme74': ours,
+                'nvme75': TestStacAdoptOnStartup._tid('10.10.10.75'),
+                'nvme76': TestStacAdoptOnStartup._tid('10.10.10.76'),  # unowned
+            }
+        )
+
+        self.assertEqual(list(adopted), [ours])
 
 
 if __name__ == '__main__':

--- a/usr/lib/systemd/system/stacd.in.service
+++ b/usr/lib/systemd/system/stacd.in.service
@@ -22,11 +22,8 @@ SyslogIdentifier=stacd
 ExecStart=/usr/bin/python3 -u /usr/sbin/stacd --syslog
 ExecReload=/bin/kill -HUP $MAINPID
 
-# Run-time directory: /run/stacd
 # Cache directory: /var/cache/stacd
-RuntimeDirectory=stacd
 CacheDirectory=stacd
-RuntimeDirectoryPreserve=yes
 
 ProtectHome=true
 ProtectKernelModules=true


### PR DESCRIPTION
stacd wrote the TIDs of the I/O controllers it managed to a pickle in $RUNTIME_DIRECTORY and, on startup, re-created a controller for each one that still had a connection in the kernel. That intersection is the tell: the kernel already knew what was connected, and the pickle only narrowed it to what had been ours. The registry answers that question now - libnvme records owner=stas on the controllers it connects for us, and claim() marks the ones we borrow - so nothing is left for stacd to remember.

Ask the kernel what is connected and the registry who owns each one. This is more robust than the file it replaces: it survives a stacd that was killed before it could write, and it cannot go stale, because the registry entry is keyed by device and goes away with it.

Adoption requires an entry naming us, rather than merely one not naming somebody else. protected() lets an unowned connection through on purpose - nobody has claimed it, so we may - but that is the wrong default here. Starting with no memory of what we were doing, an unowned connection is one we did not make: it predates the registry, or belongs to somebody who never registered it.

stafd keeps its own file. It holds the cached discovery log pages and each controller's origin, neither of which the registry can supply, so the pickle machinery moves from ServiceABC down into Staf. stacd no longer writes to $RUNTIME_DIRECTORY at all, so its unit file no longer asks for one.

Udev.get_tid() comes back, unchanged, from 27705e8 where it was dropped for want of callers.