### PR TITLE
staslib: do not talk to a discovery controller we have parked

### DIFF
--- a/staslib/ctrl.py
+++ b/staslib/ctrl.py
@@ -725,6 +725,18 @@ class Dc(Controller):
 
     def _resync_with_controller(self):
         '''Communicate with DC to resync the states'''
+        if self._parked:
+            # There is nothing to talk to. A parked DC is one we disconnected
+            # on purpose, and the events that bring us here are the tail end
+            # of that very disconnect: udev reports the connection we have
+            # already torn down, and reload_hdlr() resyncs right after asking
+            # _apply_persistence_policy() to park. Either way, resuming the
+            # conversation now only earns a NotConnectedError and a retry
+            # timer on a controller that is meant to stay down until the
+            # poll brings it back.
+            logging.debug('Dc._resync_with_controller()       - %s | %s: parked', self.id, self.device)
+            return
+
         if self._register_op:
             self._register_op.run_async()
         elif self._get_supported_op:

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -597,6 +597,16 @@ class ParkableDc(TestDc):
         self._connected = False
 
 
+class RecordingOp:
+    """An AsyncTask that records whether it was run instead of running."""
+
+    def __init__(self):
+        self.ran = False
+
+    def run_async(self):
+        self.ran = True
+
+
 class TestParking(TestCase):
     '''Unit tests for parking: a discovery controller that does not support a
     persistent connection is disconnected but kept, and polled.'''
@@ -685,6 +695,42 @@ class TestParking(TestCase):
         dc.set_connected(False)
         dc._handle_lost_controller()
         self.assertIsNotNone(dc._ctrl_unresponsive_time)
+
+    def test_a_parked_dc_does_not_resync(self):
+        """A parked DC is reached by _on_nvme_event(), when udev reports the
+        connection we already tore down, and by reload_hdlr() right after it
+        parks. Either way there is nothing connected to talk to, and asking
+        only earns a NotConnectedError and a retry timer."""
+        dc = self._dc(eflags=0)
+        dc._apply_persistence_policy()
+        self.assertTrue(dc.parked())
+
+        dc._get_log_op = RecordingOp()
+        dc._resync_with_controller()
+        self.assertFalse(dc._get_log_op.ran)
+
+    def test_a_connected_dc_still_resyncs(self):
+        """The guard must not swallow the case it is guarding against."""
+        dc = self._dc(eflags=TestParking.EPCSD)
+        dc._apply_persistence_policy()
+        self.assertFalse(dc.parked())
+
+        dc._get_log_op = RecordingOp()
+        dc._resync_with_controller()
+        self.assertTrue(dc._get_log_op.ran)
+
+    def test_a_reload_that_parks_does_not_then_resync(self):
+        """reload_hdlr() re-decides persistence and then resyncs, in that
+        order. A reload that parks the controller must not turn round and
+        talk to it."""
+        dc = self._dc(persistent='no', eflags=TestParking.EPCSD)
+        dc._get_log_op = RecordingOp()
+
+        dc._apply_persistence_policy()  # what reload_hdlr() does, in order
+        dc._resync_with_controller()
+
+        self.assertTrue(dc.parked())
+        self.assertFalse(dc._get_log_op.ran)
 
     def test_get_supported_failure_fetches_the_log_pages_anyway(self):
         """A controller that answers "unrecognized" will not answer differently


### PR DESCRIPTION
Parking disconnects a DC that does not support a persistent connection and polls it instead. The disconnect leaves a wake: udev delivers the add and change events belonging to the connection we just tore down, stafd reads the change as an NVMe "connected" event, and _resync_with_controller() starts a log page retrieval against a controller that is no longer there. It fails with NotConnectedError and arms a 20 second retry on a DC meant to stay down until the poll brings it back. The coverage run shows one of these per poll cycle.

reload_hdlr() gets there too, and by a route no udev guard would catch: it asks _apply_persistence_policy() to re-decide, which may park the controller, and then resyncs regardless. So the check belongs in _resync_with_controller(), where both callers pass through, rather than in the event handler.

_handle_lost_controller() already refuses to treat a parked DC as one that went away. This is the same reasoning applied to the other half: a DC we disconnected on purpose is not one to strike up a conversation with.