### PR TITLE
coverage: give the disconnect test something to disconnect

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -717,6 +717,14 @@ controller = transport=XM;traddr=2.2.2.2
 
 [Discovery Controller]
 controller = transport=tcp;traddr=555.555.555.555
+
+# A port nobody listens on, so the target refuses the connection outright.
+# nvmet listens on "::", which accepts everything that reaches it, so this
+# is the only entry that exercises ECONNREFUSED. Note the address has to be
+# IPv6: this phase sets "ip-family=ipv6", which would filter out 127.0.0.1
+# before we ever tried to connect.
+[Discovery Controller]
+controller = transport=tcp;traddr=::1;trsvcid=8010
 EOF
 log_file_contents 0 "${stas_conf_fname}"
 printf "\n"
@@ -767,15 +775,21 @@ print("")
 sys.exit(1)
 EOF
 
+# Wait for a connected controller rather than sampling once. A controller
+# takes a moment to come up after a reload, and a discovery controller that
+# is parked reports "nvme?" until its poll timer brings it back, so a single
+# look can miss a connection that is on its way.
 get_device() {
     local bus=$1
     local path=$2
-    dev=$(python3 ${getdev} ${bus} ${path})
-    if [[ -z "${dev}" ]]; then
-        # failed - try one more time after a short delay
-        sleep 1
+    local dev=""
+    for _ in $(seq 1 15); do
         dev=$(python3 ${getdev} ${bus} ${path})
-    fi
+        if [[ -n "${dev}" ]]; then
+            break
+        fi
+        sleep 1
+    done
     echo ${dev}
 }
 

--- a/utils/nvmet/nvmet.conf
+++ b/utils/nvmet/nvmet.conf
@@ -6,10 +6,12 @@
     'ports': [
         {
             'id': 1,
-            #'adrfam': 'ipv6',
-            #'traddr': '::',
-            'adrfam': 'ipv4',
-            'traddr': '0.0.0.0',
+            # Listen on "::" rather than "0.0.0.0": nvmet accepts both IPv4
+            # and IPv6 on the IPv6 wildcard, but only IPv4 on the IPv4 one.
+            # The coverage run needs both, because it has a phase that sets
+            # "ip-family=ipv6" and would otherwise have nothing to connect to.
+            'adrfam': 'ipv6',
+            'traddr': '::',
             'trsvcid': 8009,
             'trtype': 'tcp',
         }


### PR DESCRIPTION
The script disconnects a controller out from under stas and watches the daemon notice and reconnect. It had not done that in a long time: the phase before it sets "ip-family=ipv6", nvmet listened on 0.0.0.0, and 127.0.0.1 is the only address it answered on. So the one reachable controller was filtered out by address family, every other entry in that configuration is unreachable by design, and get_device() found nothing. Both halves printed "Failed to find a connection" in red and skipped, while the run still reported success.

nvmet listens on "::" instead. It accepts both families on the IPv6 wildcard but only IPv4 on the IPv4 one, so this is what the file's own commented-out alternative was for. The ipv6 phase now proves stas can connect over IPv6 rather than proving it cannot, which nothing else in the run covered.

That costs the one connection the target used to refuse, so a controller pointed at port 8010 takes its place. Nothing listens there, which is a sturdier way to be refused than a family mismatch, and it keeps ECONNREFUSED covered. It has to be an IPv6 address: this phase would filter out 127.0.0.1 before ever attempting to connect.

get_device() waits for a controller rather than sampling twice. One takes a moment to come up after a reload, and a parked discovery controller reports "nvme?" until its poll timer brings it back.