### PR TITLE
staslib: an IPv4-mapped address is an IPv4 address

### DIFF
--- a/coverage.sh.in
+++ b/coverage.sh.in
@@ -750,6 +750,63 @@ log ">>>>>>>>>>>>>>>>>>>>> Marker [9] <<<<<<<<<<<<<<<<<<<<<"
 printf "\n"
 
 #*******************************************************************************
+# The other side of the phase above. nvmet listens on "::", so it reports its
+# IPv4 addresses in IPv4-mapped form ("::ffff:127.0.0.1") in the discovery log
+# pages. Those name IPv4 controllers however they are spelled, and
+# "ip-family=ipv4" has to keep them: reading the mapped form as IPv6 would
+# throw away every controller this target advertises. stacd is where it
+# matters most - the mapped addresses arrive in the log pages it reads from
+# stafd - so both daemons are set to IPv4 here.
+log "Change stafd config [6]: IPv4 only, against a target reporting IPv4-mapped addresses"
+cat > "${stafd_conf_fname}" <<'EOF'
+[Global]
+tron=true
+ip-family=ipv4
+EOF
+log_file_contents 0 "${stafd_conf_fname}"
+printf "\n"
+
+log "Change stacd config [2]: IPv4 only"
+cat > "${stacd_conf_fname}" <<'EOF'
+[Global]
+tron=true
+ip-family=ipv4
+EOF
+log_file_contents 0 "${stacd_conf_fname}"
+printf "\n"
+
+cat > "${stas_conf_fname}" <<'EOF'
+[Discovery Controller Defaults]
+# nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
+# connections open anyway - that is what "force" is for.
+persistent     = force
+keep-alive-tmo = 30
+
+[Discovery Controller]
+controller = transport=tcp;traddr=localhost;trsvcid=8009
+EOF
+log_file_contents 0 "${stas_conf_fname}"
+printf "\n"
+
+reload_cfg "stafd"
+reload_cfg "stacd"
+sleep 5
+
+# Put both families back. Nothing later changes stacd.conf, and the phases
+# that follow reach subsystems over a link-local IPv6 address, which an
+# IPv4-only stacd would drop.
+log "Change stacd config [3]: both families again"
+cat > "${stacd_conf_fname}" <<'EOF'
+[Global]
+tron=true
+EOF
+log_file_contents 0 "${stacd_conf_fname}"
+printf "\n"
+
+reload_cfg "stacd"
+sleep 3
+
+#*******************************************************************************
 # Remove one of the NVMe device's
 file=/tmp/getdev-XXX.py
 getdev=$(mktemp $file)
@@ -844,7 +901,7 @@ sleep 2
 log ">>>>>>>>>>>>>>>>>>>>> Marker [11] <<<<<<<<<<<<<<<<<<<<<"
 printf "\n"
 
-log "Change stafd config [6]: connect under a persona"
+log "Change stafd config [7]: connect under a persona"
 cat > "${stafd_conf_fname}" <<'EOF'
 [Global]
 tron              = true
@@ -885,7 +942,7 @@ sleep 2
 # DC does not support a persistent connection: stafd disconnects it, keeps its
 # log pages, and comes back on the poll timer. One minute is the shortest
 # interval the option accepts, so this phase is deliberately slow.
-log "Change stafd config [7]: let a DC park, then come back"
+log "Change stafd config [8]: let a DC park, then come back"
 cat > "${stafd_conf_fname}" <<'EOF'
 [Global]
 tron                        = true
@@ -926,7 +983,7 @@ run_cmd_coverage stafctl status
 #*******************************************************************************
 # A connectivity configuration that libnvme rejects outright. stafd must keep
 # the previous one running rather than tear down working connections.
-log "Change stafd config [8]: a connectivity configuration that must be rejected"
+log "Change stafd config [9]: a connectivity configuration that must be rejected"
 cat > "${stas_conf_fname}" <<'EOF'
 [Discovery Controller Defaults]
 # nvmet never sets EFLAGS, so it always reports EPCSD=0. Hold the
@@ -962,25 +1019,19 @@ find subprojects/nvme-cli/libnvme/libnvme3/__pycache__ -maxdepth 0 -type d 2>/de
 
 #*******************************************************************************
 # Run unit tests
+#
+# Every test/test-*.py, found rather than listed: the list this replaces had
+# fallen four files behind (test-conn-conf, test-exclusions, test-protection
+# and test-singleton were never added to it), and the code they cover read as
+# untested in the report for no better reason than that.
 TEST_DIR=$( realpath ../test )
-run_unit_test ${TEST_DIR}/test-avahi.py
-run_unit_test ${TEST_DIR}/test-config.py
-run_unit_test ${TEST_DIR}/test-controller.py
-run_unit_test ${TEST_DIR}/test-defs.py
-run_unit_test ${TEST_DIR}/test-gtimer.py
-run_unit_test ${TEST_DIR}/test-gutil.py
-run_unit_test ${TEST_DIR}/test-iputil.py
-run_unit_test ${TEST_DIR}/test-log.py
-run_unit_test ${TEST_DIR}/test-nbft_conf.py
-run_unit_test ${TEST_DIR}/test-nbft.py
-run_unit_test sudo ${TEST_DIR}/test-nvme_options.py  # Test both with super user...
-run_unit_test ${TEST_DIR}/test-nvme_options.py       # ... and with regular user
-run_unit_test ${TEST_DIR}/test-service.py
-run_unit_test ${TEST_DIR}/test-stas.py
-run_unit_test ${TEST_DIR}/test-timeparse.py
-run_unit_test ${TEST_DIR}/test-transport_id.py
-run_unit_test ${TEST_DIR}/test-udev.py
-run_unit_test ${TEST_DIR}/test-version.py
+for test_file in "${TEST_DIR}"/test-*.py; do
+	run_unit_test "${test_file}"
+done
+
+# NvmeOptions probes /dev/nvme-fabrics, which reads differently depending on
+# who is asking, so it runs a second time as root.
+run_unit_test sudo ${TEST_DIR}/test-nvme_options.py
 
 #*******************************************************************************
 # Stop nvme target simulator

--- a/staslib/stas.py
+++ b/staslib/stas.py
@@ -79,8 +79,12 @@ def remove_invalid_addresses(controllers: list):
     for controller in controllers:
         if controller.transport in ('tcp', 'rdma'):
             # Let's make sure that traddr is
-            # syntactically a valid IPv4 or IPv6 address.
-            ip = iputil.get_ipaddress_obj(controller.traddr)
+            # syntactically a valid IPv4 or IPv6 address. A target listening
+            # on the IPv6 wildcard reports its IPv4 addresses in IPv4-mapped
+            # form ("::ffff:1.2.3.4"), which is an IPv4 address wearing IPv6
+            # spelling: convert it, or the family check below reads it as
+            # version 6 and "ip-family=ipv4" throws away an IPv4 controller.
+            ip = iputil.get_ipaddress_obj(controller.traddr, ipv4_mapped_convert=True)
             if ip is None:
                 logging.warning('%s IP address is not valid', controller)
                 continue
@@ -135,12 +139,14 @@ def _addresses_match(val: str, ctrl_val: str, transport: str):
     '''Return True if two addresses designate the same thing. Addresses are
     compared in normalized form, the way libnvme's exclusion list does it, so
     that two spellings of one address match: "fe80::1" designates the same
-    controller as "fe80:0000:0000:0000:0000:0000:0000:0001".'''
+    controller as "fe80:0000:0000:0000:0000:0000:0000:0001", and "1.2.3.4" the
+    same controller as the IPv4-mapped "::ffff:1.2.3.4" a target listening on
+    the IPv6 wildcard reports.'''
     if transport == 'fc':
         return _fc_wwn(val) == _fc_wwn(ctrl_val)
 
-    ip = iputil.get_ipaddress_obj(val)
-    ctrl_ip = iputil.get_ipaddress_obj(ctrl_val)
+    ip = iputil.get_ipaddress_obj(val, ipv4_mapped_convert=True)
+    ctrl_ip = iputil.get_ipaddress_obj(ctrl_val, ipv4_mapped_convert=True)
     if ip is not None and ctrl_ip is not None:
         return ip == ctrl_ip
 

--- a/test/test-controller.py
+++ b/test/test-controller.py
@@ -784,5 +784,141 @@ class TestParking(TestCase):
         self.assertFalse(dc.parked())
 
 
+class DeadObjectOp:
+    """An AsyncTask that records being killed instead of doing anything."""
+
+    def __init__(self):
+        self.killed = False
+
+    def kill(self):
+        self.killed = True
+
+
+class FakeError:
+    """The shape of the GLib error the failure callbacks log."""
+
+    domain = 'test-domain'
+    message = 'test message'
+
+    def __str__(self):
+        return FakeError.message
+
+
+class FakeUdevObject:
+    action = 'change'
+    sys_name = 'nvme666'
+
+
+class RecordingDc(TestDc):
+    """Records the work a callback would do if it got past the _alive() check."""
+
+    def __init__(self, *args, **kwargs):
+        self.registration_actions = 0
+        super().__init__(*args, **kwargs)
+
+    def _post_registration_actions(self):
+        self.registration_actions += 1
+
+
+class TestCallbacksOnADeadObject(TestCase):
+    """Every asynchronous callback can land after the controller it belongs to
+    has been torn down: the operation was already in flight when we stopped
+    caring about the answer. Each one asks _alive() first and returns. The
+    window is a scheduling race, so the integration run cannot reach these;
+    each test below names the work that must not happen."""
+
+    FAILURE_CALLBACKS = ('_on_registration_fail', '_on_get_supported_fail', '_on_get_log_fail')
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.fs.create_file(
+            '/etc/nvme/hostnqn', contents='nqn.2014-08.org.nvmexpress:uuid:01234567-0123-0123-0123-0123456789ab\n'
+        )
+        self.fs.create_file('/etc/nvme/hostid', contents='01234567-89ab-cdef-0123-456789abcdef\n')
+        self.fs.create_file('/dev/nvme-fabrics', contents='instance=-1,cntlid=-1\n')
+        conf.ConnConf.destroy()
+        self.addCleanup(conf.ConnConf.destroy)
+
+    def _dc(self, alive):
+        cid = {'transport': 'tcp', 'traddr': '1.1.1.1', 'trsvcid': '8009', 'subsysnqn': 'nqn.unrelated'}
+        dc = RecordingDc(TestStaf(), tid=trid.TID(cid))
+        if not alive:
+            dc._cancellable.cancel()  # what kill() does, and what _alive() reports on
+        self.assertEqual(dc._alive(), alive)
+        return dc
+
+    def test_a_dead_controller_does_not_reset_its_connect_attempts(self):
+        dc = self._dc(alive=False)
+        dc._connect_attempts = 5
+
+        dc._on_connect_success(DeadObjectOp(), None)
+
+        self.assertEqual(dc._connect_attempts, 5)
+
+    def test_a_dead_controller_does_not_schedule_a_reconnect(self):
+        """A failed connection normally arms the retry timer. Nobody is waiting
+        for this one any more."""
+        dc = self._dc(alive=False)
+        dc._connect_attempts = 1
+
+        dc._on_connect_fail(DeadObjectOp(), FakeError(), 1)
+
+        self.assertEqual(dc._retry_connect_tmr.time_remaining(), 0)
+
+    def test_a_dead_controller_does_not_act_on_a_registration(self):
+        dc = self._dc(alive=False)
+
+        dc._on_registration_success(DeadObjectOp(), None)
+
+        self.assertEqual(dc.registration_actions, 0)
+
+    def test_a_dead_controller_does_not_go_on_to_fetch_log_pages(self):
+        dc = self._dc(alive=False)
+
+        dc._on_get_supported_success(DeadObjectOp(), None)
+
+        self.assertIsNone(dc._get_log_op)
+
+    def test_a_dead_controller_does_not_cache_log_pages(self):
+        dc = self._dc(alive=False)
+
+        dc._on_get_log_success(DeadObjectOp(), [{'subtype': ctrl.SUBTYPE_IOC, 'traddr': '1.1.1.1'}])
+
+        self.assertEqual(dc.log_pages(), [])
+
+    def test_a_dead_controller_ignores_a_udev_event(self):
+        dc = self._dc(alive=False)
+
+        dc._on_udev_notification(FakeUdevObject())  # must not raise
+
+        self.assertEqual(dc.log_pages(), [])
+
+    def test_a_failure_callback_releases_its_operation_and_stops(self):
+        """A failed operation still has to be let go of, dead object or not."""
+        for name in TestCallbacksOnADeadObject.FAILURE_CALLBACKS:
+            with self.subTest(callback=name):
+                dc = self._dc(alive=False)
+                op = DeadObjectOp()
+
+                getattr(dc, name)(op, FakeError(), 0)
+
+                self.assertTrue(op.killed)
+                self.assertIsNone(dc._get_log_op)
+
+    def test_a_live_controller_still_does_the_work(self):
+        """The guards must not swallow the cases they are guarding against."""
+        dc = self._dc(alive=True)
+
+        dc._on_get_log_success(DeadObjectOp(), [{'subtype': ctrl.SUBTYPE_IOC, 'traddr': '1.1.1.1'}])
+        self.assertEqual(len(dc.log_pages()), 1)
+
+        dc._on_registration_success(DeadObjectOp(), None)
+        self.assertEqual(dc.registration_actions, 1)
+
+        dc._connect_attempts = 1
+        dc._on_connect_fail(DeadObjectOp(), FakeError(), 1)
+        self.assertGreater(dc._retry_connect_tmr.time_remaining(), 0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test-iputil.py
+++ b/test/test-iputil.py
@@ -5,7 +5,7 @@ import logging
 import unittest
 import ipaddress
 import subprocess
-from staslib import iputil, log, stas, trid
+from staslib import conf, iputil, log, stas, trid
 
 IP = shutil.which('ip')
 
@@ -121,6 +121,44 @@ class Test(unittest.TestCase):
 
         # IPv4-mapped IPv6 address with convert=False → stays as IPv6
         self.assertEqual(ipaddress.IPv6Address('::ffff:102:304'), iputil.get_ipaddress_obj('::ffff:1.2.3.4', ipv4_mapped_convert=False))
+
+
+
+class TestIpv4MappedAddresses(unittest.TestCase):
+    """A target listening on the IPv6 wildcard reports its IPv4 addresses in
+    IPv4-mapped form ("::ffff:10.0.0.40") in the discovery log pages. That is
+    a second spelling of "10.0.0.40", not an IPv6 address, and stas must not
+    take it for one."""
+
+    def setUp(self):
+        conf.SvcConf.destroy()
+        self.addCleanup(conf.SvcConf.destroy)
+
+    @staticmethod
+    def _tid(traddr):
+        return trid.TID({'transport': 'tcp', 'traddr': traddr, 'trsvcid': '8009', 'subsysnqn': 'nqn.probe'})
+
+    def test_a_mapped_address_survives_an_ipv4_only_family(self):
+        """It is an IPv4 address, so "ip-family=ipv4" must keep it."""
+        conf.SvcConf(default_conf={('Global', 'ip-family'): (4,)})
+        tid = TestIpv4MappedAddresses._tid('::ffff:10.0.0.40')
+
+        self.assertIn(tid, stas.remove_invalid_addresses([tid]))
+
+    def test_a_real_ipv6_address_is_still_dropped_by_an_ipv4_only_family(self):
+        """The guard must not swallow the case it is guarding against."""
+        conf.SvcConf(default_conf={('Global', 'ip-family'): (4,)})
+        tid = TestIpv4MappedAddresses._tid('2607:f8b0:4004:c06::66')
+
+        self.assertNotIn(tid, stas.remove_invalid_addresses([tid]))
+
+    def test_a_mapped_address_is_dropped_by_an_ipv6_only_family(self):
+        """It is IPv4 however it is spelled, so "ip-family=ipv6" must drop it."""
+        conf.SvcConf(default_conf={('Global', 'ip-family'): (6,)})
+        tid = TestIpv4MappedAddresses._tid('::ffff:10.0.0.40')
+
+        self.assertNotIn(tid, stas.remove_invalid_addresses([tid]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test-stas.py
+++ b/test/test-stas.py
@@ -49,6 +49,23 @@ class TestExcluded(unittest.TestCase):
         excluded = [{'transport': 'tcp'}]
         self.assertTrue(stas._excluded(excluded, {'transport': 'tcp', 'traddr': '99.99.99.99'}))
 
+    def test_a_mapped_address_matches_its_ipv4_spelling(self):
+        """A target listening on the IPv6 wildcard advertises "::ffff:1.2.3.4".
+        An "exclude=" entry naming 1.2.3.4 means that controller."""
+        excluded = [{'transport': 'tcp', 'traddr': '1.2.3.4'}]
+        self.assertTrue(stas._excluded(excluded, {'transport': 'tcp', 'traddr': '::ffff:1.2.3.4'}))
+
+    def test_an_exclusion_written_in_mapped_form_matches_the_plain_address(self):
+        """And the same the other way round, since either side may be spelled
+        either way."""
+        excluded = [{'transport': 'tcp', 'traddr': '::ffff:1.2.3.4'}]
+        self.assertTrue(stas._excluded(excluded, {'transport': 'tcp', 'traddr': '1.2.3.4'}))
+
+    def test_a_mapped_address_does_not_match_a_different_address(self):
+        """The guard must not swallow the case it is guarding against."""
+        excluded = [{'transport': 'tcp', 'traddr': '1.2.3.4'}]
+        self.assertFalse(stas._excluded(excluded, {'transport': 'tcp', 'traddr': '::ffff:5.6.7.8'}))
+
     def test_one_field_mismatch_not_excluded(self):
         excluded = [{'transport': 'tcp', 'traddr': '1.2.3.4'}]
         self.assertFalse(stas._excluded(excluded, {'transport': 'tcp', 'traddr': '5.5.5.5'}))


### PR DESCRIPTION
A target listening on the IPv6 wildcard reports its IPv4 addresses in IPv4-mapped form: a discovery log page says "::ffff:1.2.3.4" where another target would say "1.2.3.4". Python's ipaddress module gives that form version 6, and it does not compare equal to the plain address, so two places read it as an IPv6 address belonging to somebody else:

  - remove_invalid_addresses() checks the version against "ip-family". A host configured for IPv4 only threw away controllers that were IPv4, because they were spelled in IPv6.

  - _addresses_match() compares the two forms and finds them different, so "exclude=1.2.3.4" did not exclude the controller the target advertised as "::ffff:1.2.3.4" - though the function's whole purpose is to match one address written two ways.

Convert before comparing, which is what Udev._cid_matches_tid() already does at every comparison it makes; these two were the only places reading a traddr that did not. The address itself is left alone: what the target advertised is what we connect with, and the kernel takes the mapped form quite happily.

The coverage run grows a phase that sets "ip-family=ipv4" against nvmet, which now listens on "::" and so advertises mapped addresses. Both daemons keep the mapped controllers and still drop the real IPv6 ones.

While in the coverage script: run every test/test-*.py rather than the ones somebody remembered to list. The list had fallen four files behind
- test-conn-conf, test-exclusions, test-protection and test-singleton - so the code they cover read as untested. _libnvme_excluded() looked barely exercised though test-exclusions.py drives it through seven assertions; it simply was not being run.

Lastly, the callbacks. Every asynchronous callback can land after the controller it belongs to has been torn down, and each one checks _alive() and returns. That window is a scheduling race the integration run cannot reach, so nothing proved those paths did what they say. Tests now name the work that must not happen when the object is dead: no reconnect scheduled, no registration acted on, no log pages fetched or cached, and the failure callbacks still let go of their operation.

Coverage: 93% to 94%, ctrl.py 91% to 96%, conf.py 89% to 92%, singleton.py to 100%.