### PR TITLE
staslib: parse time spans the way systemd does

### DIFF
--- a/doc/stafd.conf.xml
+++ b/doc/stafd.conf.xml
@@ -246,9 +246,12 @@
                 <term><varname>dc-giveup-timeout=</varname></term>
                 <listitem>
                     <para>
-                        Takes a unit-less value in seconds, or a time span value
-                        such as "72hours" or "5days". Note that the unit is
-                        seconds, so "72" means 72 seconds and not 72 hours.
+                        Takes a systemd time span such as "72hours" or
+                        "3 days 5 hours", or a unit-less value in seconds. Note
+                        that the unit is seconds, so "72" means 72 seconds and
+                        not 72 hours. The span is parsed exactly as systemd
+                        parses one, which is also how nvme-discoverd reads this
+                        same parameter.
                         A value of 0 means no persistence. In other words,
                         configuration acquired through zeroconf (mDNS service
                         discovery) will be removed immediately when mDNS no
@@ -296,6 +299,10 @@
             <citerefentry>
                 <refentrytitle>nvme-stas.conf</refentrytitle>
                 <manvolnum>5</manvolnum>
+            </citerefentry>,
+            <citerefentry>
+                <refentrytitle>systemd.time</refentrytitle>
+                <manvolnum>7</manvolnum>
             </citerefentry>
         </para>
     </refsect1>

--- a/etc/nvme/stafd.conf
+++ b/etc/nvme/stafd.conf
@@ -93,11 +93,14 @@
 #                    fails), will be purged from the configuration after this
 #                    amount of time.
 #                    Type:  Time span.
-#                    Unit:  Takes a unit-less value in seconds, or a time span
-#                           such as "3 days 5 hours". Note the unit is seconds,
-#                           so "72" means 72 seconds, not 72 hours.
+#                    Unit:  Takes a systemd time span such as "3 days 5 hours",
+#                           or a unit-less value in seconds. Note the unit is
+#                           seconds, so "72" means 72 seconds, not 72 hours.
 #                    Range: "infinity", 0, or a time span. "infinity" means
 #                           never give up, 0 means give up immediately.
+#                    Note:  The accepted spellings are systemd's, listed in
+#                           systemd.time(7). "2hours", "2hour", "2hr" and "2h"
+#                           all work; "2hrs" does not.
 #                    Default: 72 hours (3 days)
 #dc-giveup-timeout=72hours
 

--- a/staslib/timeparse.py
+++ b/staslib/timeparse.py
@@ -1,139 +1,227 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Dell Inc. or its subsidiaries.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# See the LICENSE file for details.
+#
+# This file is part of NVMe STorage Appliance Services (nvme-stas).
+#
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+#
+'''Parse a time span the way systemd does.
 
+Implements a single function, `timeparse`, which converts a time span to a
+number of seconds. It accepts what systemd's `parse_time()` accepts and means
+the same thing by it: a sum of `<number><unit>` terms ("3 days 5 hours"),
+fractions ("1.5h"), the keyword "infinity", and a unit-less term as seconds.
+
+nvme-stas and nvme-discoverd take the same `dc-giveup-timeout` key with the
+same documented encoding, and nvme-discoverd parses it with a copy of
+systemd's `parse_time()`. A span a user writes once has to be read the same
+way by both daemons and by systemd itself. So anything below that looks like
+an arbitrary choice is not one: the suffix table, the "M" months / "m" minutes
+case distinction, systemd's month and year approximations, the truncating
+arithmetic on fractional digits and the microsecond ceiling all match systemd
+deliberately, and changing any of them breaks that agreement.
 '''
-This module was borrowed and modified from: https://github.com/wroberts/pytimeparse
 
-timeparse.py
-(c) Will Roberts <wildwilhelm@gmail.com>  1 February, 2014
+import math
 
-Implements a single function, `timeparse`, which can parse various
-kinds of time expressions.
-'''
+USEC_PER_MSEC = 1000
+USEC_PER_SEC = 1000 * USEC_PER_MSEC
+USEC_PER_MINUTE = 60 * USEC_PER_SEC
+USEC_PER_HOUR = 60 * USEC_PER_MINUTE
+USEC_PER_DAY = 24 * USEC_PER_HOUR
+USEC_PER_WEEK = 7 * USEC_PER_DAY
+USEC_PER_MONTH = 2629800 * USEC_PER_SEC  # 30.44 days, systemd's approximation
+USEC_PER_YEAR = 31557600 * USEC_PER_SEC  # 365.25 days, systemd's approximation
 
-# MIT LICENSE
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# "infinity", and the value no finite span may reach. systemd carries spans in
+# a uint64_t, and rejects anything that would reach the sentinel. Python has no
+# such limit, but the same ceiling is applied so that a span accepted here is
+# a span accepted there.
+USEC_INFINITY = 2**64 - 1
 
-import re
+# Order matters: a suffix is matched as a prefix of what remains, so the longer
+# spellings must come first. "M" is months and "m" is minutes, case-sensitive.
+MULTIPLIERS = (
+    ('seconds', USEC_PER_SEC),
+    ('second', USEC_PER_SEC),
+    ('sec', USEC_PER_SEC),
+    ('s', USEC_PER_SEC),
+    ('minutes', USEC_PER_MINUTE),
+    ('minute', USEC_PER_MINUTE),
+    ('min', USEC_PER_MINUTE),
+    ('months', USEC_PER_MONTH),
+    ('month', USEC_PER_MONTH),
+    ('M', USEC_PER_MONTH),
+    ('msec', USEC_PER_MSEC),
+    ('ms', USEC_PER_MSEC),
+    ('m', USEC_PER_MINUTE),
+    ('hours', USEC_PER_HOUR),
+    ('hour', USEC_PER_HOUR),
+    ('hr', USEC_PER_HOUR),
+    ('h', USEC_PER_HOUR),
+    ('days', USEC_PER_DAY),
+    ('day', USEC_PER_DAY),
+    ('d', USEC_PER_DAY),
+    ('weeks', USEC_PER_WEEK),
+    ('week', USEC_PER_WEEK),
+    ('w', USEC_PER_WEEK),
+    ('years', USEC_PER_YEAR),
+    ('year', USEC_PER_YEAR),
+    ('y', USEC_PER_YEAR),
+    ('usec', 1),
+    ('us', 1),
+    ('μs', 1),  # U+03BC GREEK SMALL LETTER MU
+    ('µs', 1),  # U+00B5 MICRO SIGN
+)
 
-SIGN = r'(?P<sign>[+|-])?'
-DAYS = r'(?P<days>[\d.]+)\s*(?:d|dys?|days?)'
-HOURS = r'(?P<hours>[\d.]+)\s*(?:h|hrs?|hours?)'
-MINS = r'(?P<mins>[\d.]+)\s*(?:m|(mins?)|(minutes?))'
-SECS = r'(?P<secs>[\d.]+)\s*(?:s|secs?|seconds?)'
-SEPARATORS = r'[,/]'
-SECCLOCK = r':(?P<secs>\d{2}(?:\.\d+)?)'
-MINCLOCK = r'(?P<mins>\d{1,2}):(?P<secs>\d{2}(?:\.\d+)?)'
-HOURCLOCK = r'(?P<hours>\d+):(?P<mins>\d{2}):(?P<secs>\d{2}(?:\.\d+)?)'
-DAYCLOCK = r'(?P<days>\d+):(?P<hours>\d{2}):(?P<mins>\d{2}):(?P<secs>\d{2}(?:\.\d+)?)'
+WHITESPACE = ' \t\n\r'
+DIGITS = '0123456789'
+
+INFINITY = 'infinity'
 
 
-def _opt(string):
-    return f'(?:{string})?'
+def _skip(text, index, chars):
+    '''Return the index of the first character at or after @index that is not
+    one of @chars.'''
+    while index < len(text) and text[index] in chars:
+        index += 1
+    return index
 
 
-def _optsep(string):
-    return rf'(?:{string}\s*(?:{SEPARATORS}\s*)?)?'
+def _extract_multiplier(text, index):
+    '''Match a unit suffix at @index. Return (multiplier, index-past-suffix),
+    or (None, @index) when nothing matches.'''
+    for suffix, usec in MULTIPLIERS:
+        if text.startswith(suffix, index):
+            return usec, index + len(suffix)
+
+    return None, index
 
 
-TIMEFORMATS = [
-    rf'{_optsep(DAYS)}\s*{_optsep(HOURS)}\s*{_optsep(MINS)}\s*{_opt(SECS)}',
-    f'{MINCLOCK}',
-    rf'{_optsep(DAYS)}\s*{HOURCLOCK}',
-    f'{DAYCLOCK}',
-    f'{SECCLOCK}',
-]
+def _to_seconds(usec):
+    '''Convert microseconds to seconds, as an `int` when the span is a whole
+    number of seconds and a `float` when it is not.'''
+    if usec % USEC_PER_SEC == 0:
+        return usec // USEC_PER_SEC
 
-COMPILED_SIGN = re.compile(r'\s*' + SIGN + r'\s*(?P<unsigned>.*)$')
-COMPILED_TIMEFORMATS = [re.compile(r'\s*' + timefmt + r'\s*$', re.I) for timefmt in TIMEFORMATS]
-
-MULTIPLIERS = {
-    'days': 60 * 60 * 24,
-    'hours': 60 * 60,
-    'mins': 60,
-    'secs': 1,
-}
+    return usec / USEC_PER_SEC
 
 
 def timeparse(sval):
     '''
-    Parse a time expression, returning it as a number of seconds.  If
-    possible, the return value will be an `int`; if this is not
-    possible, the return will be a `float`.  Returns `None` if a time
-    expression cannot be parsed from the given string.
+    Parse a time span the way systemd does, returning it as a number of
+    seconds. If possible, the return value will be an `int`; if this is not
+    possible, the return will be a `float`. The keyword "infinity" returns
+    `math.inf`. Returns `None` if a time span cannot be parsed from the given
+    string.
+
+    A term with no unit is a number of seconds, and terms are summed.
 
     Arguments:
     - `sval`: the string value to parse
 
-    >>> timeparse('1:24')
-    84
-    >>> timeparse(':22')
-    22
-    >>> timeparse('1 minute, 24 secs')
-    84
-    >>> timeparse('1m24s')
-    84
-    >>> timeparse('1.2 minutes')
+    >>> timeparse('72')
     72
-    >>> timeparse('1.2 seconds')
-    1.2
+    >>> timeparse('72hours')
+    259200
+    >>> timeparse('3 days 5 hours')
+    277200
+    >>> timeparse('1h30m')
+    5400
+    >>> timeparse('1.5h')
+    5400
+    >>> timeparse('500ms')
+    0.5
+    >>> timeparse('infinity')
+    inf
 
-    Time expressions can be signed.
+    Signs, colon notation and comma-separated terms are not systemd syntax.
 
-    >>> timeparse('- 1 minute')
-    -60
-    >>> timeparse('+ 1 minute')
-    60
+    >>> timeparse('-1') is None
+    True
+    >>> timeparse('1:30') is None
+    True
+    >>> timeparse('1 minute, 24 secs') is None
+    True
     '''
-    try:
-        return float(sval)
-    except TypeError:
-        pass
-    except ValueError:
-        match = COMPILED_SIGN.match(sval)
-        sign = -1 if match.groupdict()['sign'] == '-' else 1
-        sval = match.groupdict()['unsigned']
-        for timefmt in COMPILED_TIMEFORMATS:
-            match = timefmt.match(sval)
-            if match and match.group(0).strip():
-                mdict = match.groupdict()
-                # if all of the fields are integer numbers
-                if all(v.isdigit() for v in list(mdict.values()) if v):
-                    return sign * sum((MULTIPLIERS[k] * int(v, 10) for (k, v) in list(mdict.items()) if v is not None))
+    if not isinstance(sval, str):
+        return None
 
-                # if SECS is an integer number
-                if 'secs' not in mdict or mdict['secs'] is None or mdict['secs'].isdigit():
-                    # we will return an integer
-                    return sign * int(
-                        sum(
-                            (
-                                MULTIPLIERS[k] * float(v)
-                                for (k, v) in list(mdict.items())
-                                if k != 'secs' and v is not None
-                            )
-                        )
-                    ) + (int(mdict['secs'], 10) if mdict['secs'] else 0)
+    index = _skip(sval, 0, WHITESPACE)
 
-                # SECS is a float, we will return a float
-                return sign * sum((MULTIPLIERS[k] * float(v) for (k, v) in list(mdict.items()) if v is not None))
+    if sval.startswith(INFINITY, index):
+        # "infinity" may be followed by whitespace, but by nothing else.
+        if _skip(sval, index + len(INFINITY), WHITESPACE) != len(sval):
+            return None
 
-    return None
+        return math.inf
+
+    usec = 0
+    something = False
+
+    while True:
+        index = _skip(sval, index, WHITESPACE)
+        if index == len(sval):
+            return _to_seconds(usec) if something else None
+
+        if sval[index] == '-':  # rejects "-0" too
+            return None
+
+        start = index
+        digits_at = index + 1 if sval[index] == '+' else index
+        digits_end = _skip(sval, digits_at, DIGITS)
+        if digits_end > digits_at:
+            value = int(sval[start:digits_end])
+            integer_end = digits_end
+        else:
+            value = 0
+            integer_end = start  # no integer part: this may still be ".5"
+
+        fraction = integer_end < len(sval) and sval[integer_end] == '.'
+        if fraction:
+            index = _skip(sval, integer_end + 1, DIGITS)
+        elif integer_end == start:  # neither digits nor a decimal point
+            return None
+        else:
+            index = integer_end
+
+        # A suffix may be separated from its number by whitespace. When no
+        # suffix follows, the term is in seconds -- but only if whitespace or
+        # the end of the string separates it from what comes next. That is
+        # what makes "12.34 .56" a sum and "12.34.56" a syntax error.
+        before_space = index
+        multiplier, index = _extract_multiplier(sval, _skip(sval, index, WHITESPACE))
+        if multiplier is None:
+            if index == before_space and index != len(sval):
+                return None
+
+            multiplier = USEC_PER_SEC
+
+        if value >= USEC_INFINITY // multiplier:
+            return None
+
+        term = value * multiplier
+        if term >= USEC_INFINITY - usec:
+            return None
+
+        usec += term
+        something = True
+
+        if fraction:
+            # Fractional digits are consumed one at a time, each worth a tenth
+            # of the previous one, truncating as systemd does.
+            scale = multiplier // 10
+            digit_at = integer_end + 1
+            while digit_at < len(sval) and sval[digit_at] in DIGITS:
+                term = int(sval[digit_at]) * scale
+                if term >= USEC_INFINITY - usec:
+                    return None
+
+                usec += term
+                digit_at += 1
+                scale //= 10
+
+            # Rejects "0.-0", "3.+1", "3. 1", "3.sec" and "3.hoge"
+            if digit_at == integer_end + 1:
+                return None

--- a/test/test-config.py
+++ b/test/test-config.py
@@ -189,6 +189,20 @@ class TestDcGiveupTimeout(unittest.TestCase):
     def test_a_unit_less_value_is_seconds_not_hours(self):
         self.assertEqual(self._load('72').dc_giveup_timeout_sec, 72)
 
+    def test_a_span_means_what_it_means_to_systemd(self):
+        '''nvme-discoverd takes the same key and parses it with a copy of
+        systemd's parse_time(), so a span a user writes once must be read the
+        same way by both daemons. These four are where the module that used to
+        do this parsing (pytimeparse) disagreed with systemd.'''
+        self.assertEqual(self._load('500ms').dc_giveup_timeout_sec, 0.5)
+        self.assertEqual(self._load('1week').dc_giveup_timeout_sec, 7 * 24 * 60 * 60)
+        self.assertEqual(self._load('1y').dc_giveup_timeout_sec, 31557600)
+
+        # Colon notation is pytimeparse syntax that systemd does not have.
+        cnf = self._load('1:30')
+        with self.assertLogs(level='WARNING'):
+            self.assertEqual(cnf.dc_giveup_timeout_sec, 72 * 60 * 60)  # the default
+
     def test_a_negative_value_is_rejected(self):
         '''"infinity" is how forever is spelled; -1 no longer means anything.'''
         cnf = self._load('-1')

--- a/test/test-timeparse.py
+++ b/test/test-timeparse.py
@@ -1,31 +1,137 @@
 #!/usr/bin/python3
+import math
 import unittest
 from staslib import timeparse
 
+USEC_PER_SEC = timeparse.USEC_PER_SEC
+MSEC = timeparse.USEC_PER_MSEC / USEC_PER_SEC
+SEC = 1
+MINUTE = 60
+HOUR = 60 * MINUTE
+DAY = 24 * HOUR
+WEEK = timeparse.USEC_PER_WEEK // USEC_PER_SEC
+MONTH = timeparse.USEC_PER_MONTH // USEC_PER_SEC
+YEAR = timeparse.USEC_PER_YEAR // USEC_PER_SEC
+
 
 class StasTimeparseUnitTest(unittest.TestCase):
-    '''Time parse unit tests'''
+    '''Time parse unit tests.
 
-    def test_timeparse(self):
-        '''Check that timeparse() converts time spans properly'''
-        self.assertEqual(timeparse.timeparse('1'), 1)
-        self.assertEqual(timeparse.timeparse('1s'), 1)
-        self.assertEqual(timeparse.timeparse('1 sec'), 1)
-        self.assertEqual(timeparse.timeparse('1 second'), 1)
-        self.assertEqual(timeparse.timeparse('1 seconds'), 1)
-        self.assertEqual(timeparse.timeparse('1:01'), 61)
-        self.assertEqual(timeparse.timeparse('1 day'), 24 * 60 * 60)
-        self.assertEqual(timeparse.timeparse('1 hour'), 60 * 60)
-        self.assertEqual(timeparse.timeparse('1 min'), 60)
-        self.assertEqual(timeparse.timeparse('0.5'), 0.5)
-        self.assertEqual(timeparse.timeparse('-1'), -1)
-        self.assertEqual(timeparse.timeparse(':22'), 22)
-        self.assertEqual(timeparse.timeparse('1 minute, 24 secs'), 84)
-        self.assertEqual(timeparse.timeparse('1.2 minutes'), 72)
-        self.assertEqual(timeparse.timeparse('1.2 seconds'), 1.2)
-        self.assertEqual(timeparse.timeparse('- 1 minute'), -60)
-        self.assertEqual(timeparse.timeparse('+ 1 minute'), 60)
+    timeparse() must accept exactly what systemd's parse_time() accepts, and
+    mean the same thing by it, because nvme-stas and nvme-discoverd share the
+    dc-giveup-timeout encoding. These cases mirror nvme-cli's own
+    time-span tests.'''
+
+    def test_units(self):
+        '''Every suffix in the table, so a future edit that drops one is
+        caught here rather than by a user whose config stops parsing'''
+        self.assertEqual(timeparse.timeparse('1usec'), 1 / USEC_PER_SEC)
+        self.assertEqual(timeparse.timeparse('1us'), 1 / USEC_PER_SEC)
+        self.assertEqual(timeparse.timeparse('1μs'), 1 / USEC_PER_SEC)  # U+03BC
+        self.assertEqual(timeparse.timeparse('1µs'), 1 / USEC_PER_SEC)  # U+00B5
+        self.assertEqual(timeparse.timeparse('1msec'), MSEC)
+        self.assertEqual(timeparse.timeparse('500ms'), 500 * MSEC)
+        self.assertEqual(timeparse.timeparse('5s'), 5 * SEC)
+        self.assertEqual(timeparse.timeparse('5sec'), 5 * SEC)
+        self.assertEqual(timeparse.timeparse('5second'), 5 * SEC)
+        self.assertEqual(timeparse.timeparse('5seconds'), 5 * SEC)
+        self.assertEqual(timeparse.timeparse('1min'), MINUTE)
+        self.assertEqual(timeparse.timeparse('1minute'), MINUTE)
+        self.assertEqual(timeparse.timeparse('1minutes'), MINUTE)
+        self.assertEqual(timeparse.timeparse('1hr'), HOUR)
+        self.assertEqual(timeparse.timeparse('1hour'), HOUR)
+        self.assertEqual(timeparse.timeparse('1hours'), HOUR)
+        self.assertEqual(timeparse.timeparse('1d'), DAY)
+        self.assertEqual(timeparse.timeparse('1day'), DAY)
+        self.assertEqual(timeparse.timeparse('1days'), DAY)
+        self.assertEqual(timeparse.timeparse('1w'), WEEK)
+        self.assertEqual(timeparse.timeparse('1week'), WEEK)
+        self.assertEqual(timeparse.timeparse('1weeks'), WEEK)
+        self.assertEqual(timeparse.timeparse('1month'), MONTH)
+        self.assertEqual(timeparse.timeparse('1months'), MONTH)
+        self.assertEqual(timeparse.timeparse('1y'), YEAR)
+        self.assertEqual(timeparse.timeparse('1year'), YEAR)
+        self.assertEqual(timeparse.timeparse('1years'), YEAR)
+
+    def test_the_case_of_m_matters(self):
+        '''"M" is months and "m" is minutes'''
+        self.assertEqual(timeparse.timeparse('1M'), MONTH)
+        self.assertEqual(timeparse.timeparse('1m'), MINUTE)
+
+    def test_the_approximations_are_systemds(self):
+        '''A month is 30.44 days and a year is 365.25 days. Rounding either
+        one would make a span mean something else here than in a unit file.'''
+        self.assertEqual(MONTH, 2629800)
+        self.assertEqual(YEAR, 31557600)
+
+    def test_infinity(self):
+        self.assertEqual(timeparse.timeparse('infinity'), math.inf)
+        self.assertEqual(timeparse.timeparse('  infinity  '), math.inf)
+
+    def test_zero(self):
+        self.assertEqual(timeparse.timeparse('0'), 0)
+
+    def test_a_unit_less_value_is_seconds(self):
+        '''"72" is 72 seconds, not 72 hours'''
+        self.assertEqual(timeparse.timeparse('72'), 72 * SEC)
+
+    def test_terms_are_summed(self):
+        '''With or without separating whitespace'''
+        self.assertEqual(timeparse.timeparse('72hours'), 72 * HOUR)
+        self.assertEqual(timeparse.timeparse('72 h'), 72 * HOUR)
+        self.assertEqual(timeparse.timeparse('3 days 5 hours'), 3 * DAY + 5 * HOUR)
+        self.assertEqual(timeparse.timeparse('3d5h'), 3 * DAY + 5 * HOUR)
+        self.assertEqual(timeparse.timeparse('1h30m'), HOUR + 30 * MINUTE)
+        self.assertEqual(timeparse.timeparse('  2 d  '), 2 * DAY)
+
+    def test_fractions(self):
+        self.assertEqual(timeparse.timeparse('1.5h'), HOUR + 30 * MINUTE)
+        self.assertEqual(timeparse.timeparse('0.5s'), 500 * MSEC)
+        self.assertEqual(timeparse.timeparse('12.34 .56'), 12.9)
+
+    def test_a_whole_number_of_seconds_is_an_int(self):
+        '''The value ends up in GLib timers, which want a number'''
+        self.assertIsInstance(timeparse.timeparse('1'), int)
+        self.assertIsInstance(timeparse.timeparse('1.5h'), int)
+        self.assertIsInstance(timeparse.timeparse('500ms'), float)
+
+    def test_syntax_errors_are_rejected(self):
+        self.assertIsNone(timeparse.timeparse(''))
+        self.assertIsNone(timeparse.timeparse('   '))
+        self.assertIsNone(timeparse.timeparse('hours'))
+        self.assertIsNone(timeparse.timeparse('1hoge'))
+        self.assertIsNone(timeparse.timeparse('12.34.56'))
+        self.assertIsNone(timeparse.timeparse('3.sec'))
+        self.assertIsNone(timeparse.timeparse('infinityx'))
         self.assertIsNone(timeparse.timeparse('blah'))
+
+    def test_negatives_are_rejected(self):
+        '''Not clamped: say "infinity" instead'''
+        self.assertIsNone(timeparse.timeparse('-1'))
+        self.assertIsNone(timeparse.timeparse('-0'))
+        self.assertIsNone(timeparse.timeparse('1h -1m'))
+
+    def test_overflow_is_rejected(self):
+        '''On the multiply, and on the sum of two valid terms'''
+        self.assertIsNone(timeparse.timeparse('100000000000000y'))
+        self.assertIsNone(timeparse.timeparse('300000y 300000y'))
+
+    def test_pytimeparse_syntax_is_gone(self):
+        '''This module used to be pytimeparse, which accepted colon notation,
+        comma-separated terms and signs. systemd accepts none of the three,
+        and a span must mean the same thing in both daemons.'''
+        self.assertIsNone(timeparse.timeparse('1:30'))
+        self.assertIsNone(timeparse.timeparse('1:01'))
+        self.assertIsNone(timeparse.timeparse(':22'))
+        self.assertIsNone(timeparse.timeparse('1 minute, 24 secs'))
+        self.assertIsNone(timeparse.timeparse('- 1 minute'))
+        self.assertIsNone(timeparse.timeparse('+ 1 minute'))
+
+    def test_a_non_string_is_rejected(self):
+        '''conf.py hands us whatever the config file yielded, including None
+        when the key was empty'''
+        self.assertIsNone(timeparse.timeparse(None))
+        self.assertIsNone(timeparse.timeparse(72))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
dc-giveup-timeout is documented as a time span, and nvme-discoverd takes the same key with the same encoding, parsing it with a copy of systemd's parse_time(). A span a user writes once has to mean the same thing in both daemons. It did not: timeparse.py was a vendored copy of pytimeparse, which has a grammar of its own.

  500ms   systemd 0.5s       pytimeparse rejected
  1week   systemd 604800s    pytimeparse rejected
  1y      systemd 31557600s  pytimeparse rejected
  1:30    systemd rejected   pytimeparse 90s

The parser now implements systemd's grammar, including the suffix table, the "M" months / "m" minutes case distinction, the 30.44-day month and 365.25-day year, and the truncating arithmetic on fractional digits. Nothing of pytimeparse remains, so the file drops the vendored MIT notice it no longer owes and takes the same header as the rest of staslib.

Spans only pytimeparse accepted now fall back to the default with a warning: "hrs"/"secs"/"mins"/"dy", uppercase, comma-separated terms, colon notation, and "inf"/"1e5"/"nan". One value keeps parsing and changes meaning: "1M" was 60 seconds and is now one month.

stafd.conf(5) and the sample stafd.conf now point at systemd.time(7). The tests mirror nvme-cli's, and every case was checked against the host's systemd-analyze timespan.